### PR TITLE
24: [FEAT] 사용자 기능 API (약 복용 기록 조회) 구현

### DIFF
--- a/src/main/java/com/mednine/pillbuddy/domain/record/dto/RecordDTO.java
+++ b/src/main/java/com/mednine/pillbuddy/domain/record/dto/RecordDTO.java
@@ -1,0 +1,26 @@
+package com.mednine.pillbuddy.domain.record.dto;
+
+import com.mednine.pillbuddy.domain.record.entity.Record;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class RecordDTO {
+
+    private Long recordId;
+    private LocalDateTime date;
+    private String medicationName;
+    private String taken;
+
+    public RecordDTO(Record record) {
+        this.recordId = record.getId();
+        this.date = record.getDate();
+        this.medicationName = record.getUserMedication().getName();
+        this.taken = record.getTaken().toString();
+    }
+}

--- a/src/main/java/com/mednine/pillbuddy/domain/user/caretaker/controller/CaretakerController.java
+++ b/src/main/java/com/mednine/pillbuddy/domain/user/caretaker/controller/CaretakerController.java
@@ -1,13 +1,17 @@
 package com.mednine.pillbuddy.domain.user.caretaker.controller;
 
+import com.mednine.pillbuddy.domain.record.dto.RecordDTO;
 import com.mednine.pillbuddy.domain.user.caretaker.dto.CaretakerCaregiverDTO;
 import com.mednine.pillbuddy.domain.user.caretaker.service.CaretakerService;
-import com.mednine.pillbuddy.domain.user.caretaker.service.CaretakerServiceImpl;
+import com.mednine.pillbuddy.domain.userMedication.service.UserMedicationService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
+import java.util.List;
 import java.util.Map;
 
 @RestController
@@ -16,6 +20,7 @@ import java.util.Map;
 public class CaretakerController {
 
     private final CaretakerService caretakerService;
+    private final UserMedicationService userMedicationService;
 
     @PostMapping("/{caretakerId}/caregivers/{caregiverId}")
     public ResponseEntity<CaretakerCaregiverDTO> addCaregiver(@PathVariable Long caretakerId, @PathVariable Long caregiverId) {
@@ -28,6 +33,14 @@ public class CaretakerController {
         caretakerService.remove(caretakerId, caregiverId);
         Map<String, String> result = Map.of("Process", "Success");
         return ResponseEntity.ok(result);
+    }
+
+    @GetMapping("/{caretakerId}/user-medications/records")
+    public ResponseEntity<List<RecordDTO>> getRecordsByDate(
+            @PathVariable Long caretakerId,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
+        List<RecordDTO> records = userMedicationService.getUserMedicationRecordsByDate(caretakerId, date.atStartOfDay());
+        return ResponseEntity.ok(records);
     }
 }
 

--- a/src/main/java/com/mednine/pillbuddy/domain/user/caretaker/repository/CaretakerCaregiverRepository.java
+++ b/src/main/java/com/mednine/pillbuddy/domain/user/caretaker/repository/CaretakerCaregiverRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface CaretakerCaregiverRepository extends JpaRepository<CaretakerCaregiver, Long> {
-    Optional<CaretakerCaregiver> findByCaretaker_IdAndCaregiver_Id(Long caretakerId, Long caregiverId);
+    Optional<CaretakerCaregiver> findByCaretakerIdAndCaregiverId(Long caretakerId, Long caregiverId);
 }

--- a/src/main/java/com/mednine/pillbuddy/domain/user/caretaker/service/CaretakerServiceImpl.java
+++ b/src/main/java/com/mednine/pillbuddy/domain/user/caretaker/service/CaretakerServiceImpl.java
@@ -1,7 +1,7 @@
 package com.mednine.pillbuddy.domain.user.caretaker.service;
 
 import com.mednine.pillbuddy.domain.user.caregiver.entity.Caregiver;
-import com.mednine.pillbuddy.domain.user.caregiver.entity.repository.CaregiverRepository;
+import com.mednine.pillbuddy.domain.user.caregiver.repository.CaregiverRepository;
 import com.mednine.pillbuddy.domain.user.caretaker.dto.CaretakerCaregiverDTO;
 import com.mednine.pillbuddy.domain.user.caretaker.entity.Caretaker;
 import com.mednine.pillbuddy.domain.user.caretaker.entity.CaretakerCaregiver;
@@ -37,7 +37,7 @@ public class CaretakerServiceImpl implements CaretakerService {
                 .caretaker(caretaker)
                 .build();
 
-        if (caretakerCaregiverRepository.findByCaretaker_IdAndCaregiver_Id(caretakerId, caregiverId).isPresent()) {
+        if (caretakerCaregiverRepository.findByCaretakerIdAndCaregiverId(caretakerId, caregiverId).isPresent()) {
             throw new PillBuddyCustomException(ErrorCode.CARETAKER_CAREGIVER_NOT_REGISTERED);
         }
 
@@ -49,7 +49,7 @@ public class CaretakerServiceImpl implements CaretakerService {
     @Transactional
     public void remove(Long caretakerId, Long caregiverId) {
         CaretakerCaregiver caretakerCaregiver = caretakerCaregiverRepository
-                .findByCaretaker_IdAndCaregiver_Id(caretakerId, caregiverId)
+                .findByCaretakerIdAndCaregiverId(caretakerId, caregiverId)
                 .orElseThrow(() -> new PillBuddyCustomException(ErrorCode.CARETAKER_CAREGIVER_NOT_MATCHED));
 
         caretakerCaregiverRepository.delete(caretakerCaregiver);

--- a/src/main/java/com/mednine/pillbuddy/domain/userMedication/service/UserMedicationService.java
+++ b/src/main/java/com/mednine/pillbuddy/domain/userMedication/service/UserMedicationService.java
@@ -1,7 +1,9 @@
 package com.mednine.pillbuddy.domain.userMedication.service;
 
+import com.mednine.pillbuddy.domain.record.dto.RecordDTO;
 import com.mednine.pillbuddy.domain.userMedication.dto.UserMedicationDTO;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface UserMedicationService {
@@ -11,4 +13,6 @@ public interface UserMedicationService {
     List<UserMedicationDTO> retrieve(Long caretakerId);
 
     UserMedicationDTO modify(Long caretakerId, Long userMedicationId, UserMedicationDTO userMedicationDTO);
+
+    List<RecordDTO> getUserMedicationRecordsByDate(Long caretakerId, LocalDateTime date);
 }

--- a/src/main/java/com/mednine/pillbuddy/domain/userMedication/service/UserMedicationServiceImpl.java
+++ b/src/main/java/com/mednine/pillbuddy/domain/userMedication/service/UserMedicationServiceImpl.java
@@ -1,5 +1,7 @@
 package com.mednine.pillbuddy.domain.userMedication.service;
 
+import com.mednine.pillbuddy.domain.record.dto.RecordDTO;
+import com.mednine.pillbuddy.domain.record.entity.Record;
 import com.mednine.pillbuddy.domain.user.caretaker.entity.Caretaker;
 import com.mednine.pillbuddy.domain.user.caretaker.repository.CaretakerRepository;
 import com.mednine.pillbuddy.domain.userMedication.dto.UserMedicationDTO;
@@ -12,6 +14,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -67,5 +71,22 @@ public class UserMedicationServiceImpl implements UserMedicationService {
             log.error(e.getMessage());
             throw e;
         }
+    }
+
+    @Override
+    public List<RecordDTO> getUserMedicationRecordsByDate(Long caretakerId, LocalDateTime date) {
+        List<UserMedication> userMedications = userMedicationRepository.findByCaretakerId(caretakerId);
+        List<RecordDTO> recordDTOList = new ArrayList<>();
+
+        for (UserMedication medication : userMedications) {
+            List<Record> records = medication.getRecords().stream()
+                    .filter(record -> record.getDate().toLocalDate().equals(date.toLocalDate()))
+                    .toList();
+
+            for (Record record : records) {
+                recordDTOList.add(new RecordDTO(record));
+            }
+        }
+        return recordDTOList;
     }
 }

--- a/src/test/java/com/mednine/pillbuddy/domain/user/caretaker/controller/CaretakerControllerTest.java
+++ b/src/test/java/com/mednine/pillbuddy/domain/user/caretaker/controller/CaretakerControllerTest.java
@@ -1,35 +1,68 @@
 package com.mednine.pillbuddy.domain.user.caretaker.controller;
 
+import com.mednine.pillbuddy.domain.record.dto.RecordDTO;
 import com.mednine.pillbuddy.domain.user.caretaker.dto.CaretakerCaregiverDTO;
-import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
 @SpringBootTest
 public class CaretakerControllerTest {
+
     @Autowired
     private CaretakerController caretakerController;
 
     @Test
     @Transactional
+    @DisplayName("사용자 기능 중 보호자 추가 기능 테스트")
     public void addCaregiver() {
         Long caretakerId = 2L;
         Long caregiverId = 1L;
 
         ResponseEntity<CaretakerCaregiverDTO> caretakerCaregiver = caretakerController.addCaregiver(caretakerId, caregiverId);
 
-        Assertions.assertThat(caretakerCaregiver).isNotNull();
-        Assertions.assertThat(caretakerCaregiver.getBody()).isNotNull();
+        assertThat(caretakerCaregiver).isNotNull();
+        assertThat(caretakerCaregiver.getBody()).isNotNull();
     }
 
     @Test
+    @DisplayName("사용자 기능 중 보호자 삭제 기능 테스트")
     public void caretakerServiceTests3() {
         Long caretakerId = 2L;
         Long caregiverId = 2L;
 
         caretakerController.deleteCaregiver(caretakerId, caregiverId);
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("사용자의 날짜 별 약 복용 여부 조회 테스트")
+    public void getRecordsByDate() {
+        Long caretakerId = 1L;
+        String sampleDate = "2024-09-25";
+
+        LocalDate date = LocalDate.parse(sampleDate);
+
+        ResponseEntity<List<RecordDTO>> recordsByDate = caretakerController.getRecordsByDate(caretakerId, date);
+
+        assertThat(recordsByDate.getBody()).isNotNull();
+        assertThat(recordsByDate.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        RecordDTO recordDTO = recordsByDate.getBody().get(0);
+
+        assertThat(recordDTO).isNotNull(); // 첫 번째 레코드가 null이 아닌지 확인
+        assertThat(recordDTO.getRecordId()).isEqualTo(1); // recordId 검증
+        assertThat(recordDTO.getDate().toString()).isEqualTo("2024-09-25T09:00"); // 날짜 검증
+        assertThat(recordDTO.getMedicationName()).isEqualTo("Aspirin"); // 약 이름 검증
+        assertThat(recordDTO.getTaken()).isEqualTo("TAKEN"); // 복용 여부 검증
     }
 }


### PR DESCRIPTION
## 👩‍💻작업 내용
약 복용 기록 조회 (날짜 별 복용 여부)
1. catakerId와 날짜 정보를 매개 변수로 받아 특정 일자에 어떤 약을 복용했는 지 여부를 조회 가능
2. recordDTO를 따로 설정하여 record pk id, 검색 일자, 약 종류, 복용 여부 4가지가 나오도록 설정
3. 
![image](https://github.com/user-attachments/assets/0a7640ba-7758-4c11-8019-39311b9ea3da)
테스트 코드 만들어 진행했고, talend api의 결과는 다음과 같음 
4. 코드 일부 리팩토링 
## 💬리뷰 요구 사항
오타 및 로직 오류 
## 📃참고 자료
