### PR TITLE
31:[FEAT] 회원 로그아웃 기능 구현

### DIFF
--- a/src/main/java/com/mednine/pillbuddy/domain/user/controller/UserController.java
+++ b/src/main/java/com/mednine/pillbuddy/domain/user/controller/UserController.java
@@ -37,4 +37,11 @@ public class UserController {
 
         return ResponseEntity.ok(jwtToken);
     }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout() {
+        userService.logout();
+
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/mednine/pillbuddy/domain/user/service/UserService.java
+++ b/src/main/java/com/mednine/pillbuddy/domain/user/service/UserService.java
@@ -15,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -69,5 +70,14 @@ public class UserService {
         Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
 
         return jwtTokenProvider.generateToken(authentication);
+    }
+
+    public void logout() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null) {
+            throw new PillBuddyCustomException(ErrorCode.USER_AUTHENTICATION_REQUIRED);
+        }
+        SecurityContextHolder.clearContext();
     }
 }

--- a/src/main/java/com/mednine/pillbuddy/global/exception/ErrorCode.java
+++ b/src/main/java/com/mednine/pillbuddy/global/exception/ErrorCode.java
@@ -1,15 +1,19 @@
 package com.mednine.pillbuddy.global.exception;
 
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.CONFLICT;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-
-import static org.springframework.http.HttpStatus.*;
 
 @Getter
 @RequiredArgsConstructor
 public enum ErrorCode {
 
+    USER_AUTHENTICATION_REQUIRED(UNAUTHORIZED, "인증이 필요한 회원입니다."),
     USER_NOT_FOUND(NOT_FOUND, "회원 정보를 찾을 수 없습니다."),
     USER_ALREADY_REGISTERED_EMAIL(CONFLICT, "이미 등록된 이메일입니다."),
     USER_ALREADY_REGISTERED_LOGIN_ID(CONFLICT, "이미 등록된 아이디입니다."),
@@ -19,7 +23,7 @@ public enum ErrorCode {
     JWT_TOKEN_INVALID(UNAUTHORIZED, "유효하지 않은 JWT 토큰입니다."),
     JWT_TOKEN_EXPIRED(UNAUTHORIZED, "JWT 토큰이 만료되었습니다."),
     JWT_TOKEN_UNSUPPORTED(BAD_REQUEST, "지원되지 않는 JWT 토큰입니다."),
-  
+
     MEDICATION_NOT_FOUND(NOT_FOUND, "약 정보를 찾을 수 없습니다."),
     MEDICATION_NOT_MATCHED(BAD_REQUEST, "약 정보가 일치하지 않습니다."),
     MEDICATION_NOT_REMOVED(CONFLICT, "약 정보 삭제에 실패했습니다."),


### PR DESCRIPTION
## 👩‍💻작업 내용
로그아웃 기능은 프론트에서 토큰을 제거해주면 되기 떄문에 복잡한 기능은 없습니다.
service 에서 사용자의 인증 정보를 가져오고, 인증 정보를 삭제합니다.
