### PR TITLE
35:[FEAT] 토큰 재발급 기능

### DIFF
--- a/src/main/java/com/mednine/pillbuddy/domain/user/controller/UserController.java
+++ b/src/main/java/com/mednine/pillbuddy/domain/user/controller/UserController.java
@@ -6,25 +6,24 @@ import com.mednine.pillbuddy.domain.user.dto.UserDto;
 import com.mednine.pillbuddy.domain.user.service.UserService;
 import com.mednine.pillbuddy.global.jwt.JwtToken;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/users")
 @RequiredArgsConstructor
-@Slf4j
 public class UserController {
 
     private final UserService userService;
 
     @PostMapping("/join")
     public ResponseEntity<UserDto> join(@Validated @RequestBody JoinDto joinDto) {
-        log.info("-- UserController.join() called !!");
         UserDto userDto = userService.join(joinDto);
 
         return ResponseEntity.ok(userDto);
@@ -32,7 +31,6 @@ public class UserController {
 
     @PostMapping("/login")
     public ResponseEntity<JwtToken> login(@RequestBody LoginDto loginDto) {
-        log.info("-- UserController.login() called !!");
         JwtToken jwtToken = userService.login(loginDto);
 
         return ResponseEntity.ok(jwtToken);
@@ -43,5 +41,12 @@ public class UserController {
         userService.logout();
 
         return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/reissue-token")
+    public ResponseEntity<JwtToken> reissueToken(@RequestHeader(HttpHeaders.AUTHORIZATION) String bearerToken) {
+        JwtToken jwtToken = userService.reissueToken(bearerToken);
+
+        return ResponseEntity.ok(jwtToken);
     }
 }

--- a/src/main/java/com/mednine/pillbuddy/domain/user/service/UserService.java
+++ b/src/main/java/com/mednine/pillbuddy/domain/user/service/UserService.java
@@ -32,32 +32,13 @@ public class UserService {
     private final JwtTokenProvider jwtTokenProvider;
 
     public UserDto join(JoinDto joinDto) {
-        // 회원가입 유효성 검증
-        if (caregiverRepository.existsByLoginId(joinDto.getLoginId()) || caretakerRepository.existsByLoginId(
-                joinDto.getLoginId())) {
-            throw new PillBuddyCustomException(ErrorCode.USER_ALREADY_REGISTERED_LOGIN_ID);
-        }
-        if (caregiverRepository.existsByEmail(joinDto.getEmail()) || caretakerRepository.existsByEmail(
-                joinDto.getEmail())) {
-            throw new PillBuddyCustomException(ErrorCode.USER_ALREADY_REGISTERED_EMAIL);
-        }
-        if (caregiverRepository.existsByPhoneNumber(joinDto.getPhoneNumber())
-                || caretakerRepository.existsByPhoneNumber(joinDto.getPhoneNumber())) {
-            throw new PillBuddyCustomException(ErrorCode.USER_ALREADY_REGISTERED_PHONE_NUMBER);
-        }
-
+        validateJoinInfo(joinDto);
         joinDto.encodePassword(passwordEncoder);
 
         // 사용자 타입에 따라 회원 저장
         return switch (joinDto.getUserType()) {
-            case CAREGIVER -> {
-                Caregiver savedCaregiver = caregiverRepository.save(joinDto.toCaregiverEntity());
-                yield new UserDto(savedCaregiver);
-            }
-            case CARETAKER -> {
-                Caretaker savedCaretaker = caretakerRepository.save(joinDto.toCaretakerEntity());
-                yield new UserDto(savedCaretaker);
-            }
+            case CAREGIVER -> new UserDto(caregiverRepository.save(joinDto.toCaregiverEntity()));
+            case CARETAKER -> new UserDto(caretakerRepository.save(joinDto.toCaretakerEntity()));
         };
     }
 
@@ -72,6 +53,7 @@ public class UserService {
         return jwtTokenProvider.generateToken(authentication);
     }
 
+    @Transactional(propagation = Propagation.NEVER)
     public void logout() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
@@ -79,5 +61,34 @@ public class UserService {
             throw new PillBuddyCustomException(ErrorCode.USER_AUTHENTICATION_REQUIRED);
         }
         SecurityContextHolder.clearContext();
+    }
+
+    @Transactional(readOnly = true)
+    public JwtToken reissueToken(String bearerToken) {
+        // 토큰 가져오기
+        String refreshToken = jwtTokenProvider.resolveToken(bearerToken);
+
+        // 토큰 유효성 검사
+        if (refreshToken == null || !jwtTokenProvider.validateToken(refreshToken)) {
+            throw new PillBuddyCustomException(ErrorCode.JWT_TOKEN_INVALID);
+        }
+
+        return jwtTokenProvider.reissueAccessToken(refreshToken);
+    }
+
+    private void validateJoinInfo(JoinDto joinDto) {
+        // 회원가입 유효성 검증
+        if (caregiverRepository.existsByLoginId(joinDto.getLoginId()) || caretakerRepository.existsByLoginId(
+                joinDto.getLoginId())) {
+            throw new PillBuddyCustomException(ErrorCode.USER_ALREADY_REGISTERED_LOGIN_ID);
+        }
+        if (caregiverRepository.existsByEmail(joinDto.getEmail()) || caretakerRepository.existsByEmail(
+                joinDto.getEmail())) {
+            throw new PillBuddyCustomException(ErrorCode.USER_ALREADY_REGISTERED_EMAIL);
+        }
+        if (caregiverRepository.existsByPhoneNumber(joinDto.getPhoneNumber())
+                || caretakerRepository.existsByPhoneNumber(joinDto.getPhoneNumber())) {
+            throw new PillBuddyCustomException(ErrorCode.USER_ALREADY_REGISTERED_PHONE_NUMBER);
+        }
     }
 }

--- a/src/main/java/com/mednine/pillbuddy/domain/user/service/UserService.java
+++ b/src/main/java/com/mednine/pillbuddy/domain/user/service/UserService.java
@@ -1,8 +1,6 @@
 package com.mednine.pillbuddy.domain.user.service;
 
-import com.mednine.pillbuddy.domain.user.caregiver.entity.Caregiver;
 import com.mednine.pillbuddy.domain.user.caregiver.repository.CaregiverRepository;
-import com.mednine.pillbuddy.domain.user.caretaker.entity.Caretaker;
 import com.mednine.pillbuddy.domain.user.caretaker.repository.CaretakerRepository;
 import com.mednine.pillbuddy.domain.user.dto.JoinDto;
 import com.mednine.pillbuddy.domain.user.dto.LoginDto;
@@ -18,6 +16,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service

--- a/src/main/java/com/mednine/pillbuddy/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/mednine/pillbuddy/global/jwt/JwtAuthenticationFilter.java
@@ -5,8 +5,6 @@ import com.mednine.pillbuddy.global.exception.ErrorResponse;
 import com.mednine.pillbuddy.global.exception.PillBuddyCustomException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
-import jakarta.servlet.ServletRequest;
-import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -16,20 +14,21 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
-import org.springframework.web.filter.GenericFilterBean;
+import org.springframework.web.filter.OncePerRequestFilter;
 
 @Component
 @RequiredArgsConstructor
 @Slf4j
-public class JwtAuthenticationFilter extends GenericFilterBean {
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final ObjectMapper objectMapper;
 
     @Override
-    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
         try {
-            String token = jwtTokenProvider.resolveToken((HttpServletRequest) request);
+            String token = jwtTokenProvider.resolveToken(request);
 
             // token 유효성 검증
             if (token != null && jwtTokenProvider.validateToken(token)) {
@@ -39,7 +38,7 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
 
             chain.doFilter(request, response);
         } catch (PillBuddyCustomException e) {
-            handleException((HttpServletResponse) response, e);
+            handleException(response, e);
         }
     }
 

--- a/src/main/java/com/mednine/pillbuddy/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/mednine/pillbuddy/global/jwt/JwtAuthenticationFilter.java
@@ -32,14 +32,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
             // token 유효성 검증
             if (token != null && jwtTokenProvider.validateToken(token)) {
-                Authentication authentication = jwtTokenProvider.getAuthentication(token);
+                // token 의 loginId 를 통해 권한 정보를 조회하여 SecurityContext 에 저장
+                Authentication authentication = jwtTokenProvider.getAuthenticationByToken(token);
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             }
-
-            chain.doFilter(request, response);
         } catch (PillBuddyCustomException e) {
             handleException(response, e);
         }
+
+        chain.doFilter(request, response);
     }
 
     private void handleException(HttpServletResponse response, PillBuddyCustomException e) throws IOException {

--- a/src/main/java/com/mednine/pillbuddy/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/mednine/pillbuddy/global/jwt/JwtAuthenticationFilter.java
@@ -10,6 +10,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -28,7 +29,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
             throws ServletException, IOException {
         try {
-            String token = jwtTokenProvider.resolveToken(request);
+            String bearerToken = request.getHeader(HttpHeaders.AUTHORIZATION);
+            String token = jwtTokenProvider.resolveToken(bearerToken);
 
             // token 유효성 검증
             if (token != null && jwtTokenProvider.validateToken(token)) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,5 +16,5 @@ logging:
 jwt:
   token:
     client-secret: e15f6da6387aed17fc517949bf26ac808dc81446ab913e0a51468025b8c9344e
-    access-expiration-time: 3600000 # 60분
-    refresh-expiration-time: 18000000  # 5시간
+    access-expiration-time: 300000 # 5분
+    refresh-expiration-time: 86400000  # 24시간

--- a/src/test/java/com/mednine/pillbuddy/domain/user/caretaker/repository/CaretakerRepositoryTest.java
+++ b/src/test/java/com/mednine/pillbuddy/domain/user/caretaker/repository/CaretakerRepositoryTest.java
@@ -81,7 +81,7 @@ class CaretakerRepositoryTest {
         Long caretakerId = 1L;
         Long caregiverId = 1L;
 
-        CaretakerCaregiver caretakerCaregiver = caretakerCaregiverRepository.findByCaretaker_IdAndCaregiver_Id(caretakerId, caregiverId).orElse(null);
+        CaretakerCaregiver caretakerCaregiver = caretakerCaregiverRepository.findByCaretakerIdAndCaregiverId(caretakerId, caregiverId).orElse(null);
 
         assertThat(caretakerCaregiver.getId()).isEqualTo(1);
         assertThat(caretakerCaregiver.getCaretaker().getId()).isEqualTo(1);

--- a/src/test/java/com/mednine/pillbuddy/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/mednine/pillbuddy/domain/user/service/UserServiceTest.java
@@ -99,7 +99,7 @@ class UserServiceTest {
 
         // when
         JwtToken jwtToken = userService.login(loginDto);
-        Authentication authentication = jwtTokenProvider.getAuthentication(jwtToken.getAccessToken());
+        Authentication authentication = jwtTokenProvider.getAuthenticationByToken(jwtToken.getAccessToken());
 
         // then
         assertThat(jwtToken.getGrantType()).isEqualTo("Bearer");

--- a/src/test/java/com/mednine/pillbuddy/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/mednine/pillbuddy/domain/user/service/UserServiceTest.java
@@ -134,4 +134,45 @@ class UserServiceTest {
         }).isInstanceOf(BadCredentialsException.class)
                 .hasMessage("Bad credentials");
     }
+
+    @Test
+    @DisplayName("사용자는 refreshToken 을 통해 토큰을 재발급 할 수 있다.")
+    void reissueToken() {
+        // given
+        LoginDto loginDto = new LoginDto("caregiver3", "password3");
+
+        JwtToken jwtToken = userService.login(loginDto);
+        String refreshToken = "Bearer " + jwtToken.getRefreshToken();
+
+        // when
+        JwtToken reissuedJwtToken = userService.reissueToken(refreshToken);
+        String reissuedAccessToken = reissuedJwtToken.getAccessToken();
+        Authentication authentication = jwtTokenProvider.getAuthenticationByToken(reissuedAccessToken);
+
+        // then
+        assertThat(authentication.getName()).isEqualTo("caregiver3");
+        assertThat(authentication.getAuthorities().iterator().next().getAuthority()).isEqualTo("ROLE_USER");
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 refreshToken 이면, PillBuddyException 이 발생한다.")
+    void reissueToken_with_expired_refreshToken() {
+        // given
+        String malformedRefreshToken = "Bearer malformed_jwt_token";
+
+        assertThatThrownBy(() -> userService.reissueToken(malformedRefreshToken))
+                .isInstanceOf(PillBuddyCustomException.class)
+                .hasMessage("유효하지 않은 JWT 토큰입니다.");
+    }
+
+    @Test
+    @DisplayName("GrantType 이 없는 refreshToken 이면, PillBuddyException 이 발생한다.")
+    void reissueToken_without_grantType() {
+        // given
+        String refreshToken = "simple_refresh_token";
+
+        assertThatThrownBy(() -> userService.reissueToken(refreshToken))
+                .isInstanceOf(PillBuddyCustomException.class)
+                .hasMessage("유효하지 않은 JWT 토큰입니다.");
+    }
 }


### PR DESCRIPTION
## 👩‍💻작업 내용
- [x] Filter 클래스의 상속 대상을 OncePerRequestFilter 로 변경
- [x] 토큰 유효시간 변경
- [x] 토큰 발급 로직 리팩토링 & 주석 추가
- [x] 토큰 재발급 기능 구현
- [x] 테스트 코드 작성

## 💬리뷰 요구 사항
코드 중복을 줄이기 위해 JwtTokenProvider 클래스의 많은 수정을 거쳤는데, 로직이 괜찮은지 확인 부탁드립니다 !
그리고 원래 refreshToken 에는 유효기간만 작성하였었는데, 토큰 재발급 기능을 구현하면서 사용자의 로그인 아이디 정도만 claim에 추가하였습니다. 

추가로 refreshToken 을 대상으로한 BlackList 테이블을 만들어서, 재발급한 refreshToken 값을 다시 사용하지 못하도록 저장하는 방법이 있다고 합니다. 이 방법을 사용하면 보안상 이점이 많을 것 같아서 추후에 시간이 되면 추가해보도록 하겠습니다 !
-> [참고자료](https://engineerinsight.tistory.com/278)

## 📃참고 자료

