### PR TITLE
52:[FEAT] 사용자 및 보호자 엔티티의 조회 기능 구현

### DIFF
--- a/src/main/java/com/mednine/pillbuddy/domain/user/caregiver/repository/CaregiverRepository.java
+++ b/src/main/java/com/mednine/pillbuddy/domain/user/caregiver/repository/CaregiverRepository.java
@@ -2,6 +2,7 @@ package com.mednine.pillbuddy.domain.user.caregiver.repository;
 
 import com.mednine.pillbuddy.domain.user.caregiver.entity.Caregiver;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CaregiverRepository extends JpaRepository<Caregiver, Long> {
@@ -10,4 +11,7 @@ public interface CaregiverRepository extends JpaRepository<Caregiver, Long> {
     boolean existsByLoginId(String loginId);
     boolean existsByEmail(String email);
     boolean existsByPhoneNumber(String phoneNumber);
+
+    @EntityGraph(attributePaths = {"image"})
+    Optional<Caregiver> findById(Long id);
 }

--- a/src/main/java/com/mednine/pillbuddy/domain/user/caretaker/repository/CaretakerRepository.java
+++ b/src/main/java/com/mednine/pillbuddy/domain/user/caretaker/repository/CaretakerRepository.java
@@ -2,6 +2,7 @@ package com.mednine.pillbuddy.domain.user.caretaker.repository;
 
 import com.mednine.pillbuddy.domain.user.caretaker.entity.Caretaker;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CaretakerRepository extends JpaRepository<Caretaker, Long> {
@@ -10,4 +11,7 @@ public interface CaretakerRepository extends JpaRepository<Caretaker, Long> {
     boolean existsByLoginId(String loginId);
     boolean existsByEmail(String email);
     boolean existsByPhoneNumber(String phoneNumber);
+
+    @EntityGraph(attributePaths = {"image"})
+    Optional<Caretaker> findById(Long id);
 }

--- a/src/main/java/com/mednine/pillbuddy/domain/user/controller/UserController.java
+++ b/src/main/java/com/mednine/pillbuddy/domain/user/controller/UserController.java
@@ -6,7 +6,6 @@ import com.mednine.pillbuddy.domain.user.dto.UserDto;
 import com.mednine.pillbuddy.domain.user.dto.UserType;
 import com.mednine.pillbuddy.domain.user.service.UserService;
 import com.mednine.pillbuddy.global.jwt.JwtToken;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
@@ -59,29 +58,5 @@ public class UserController {
         UserDto userDto = userService.findUser(userId, userType);
 
         return ResponseEntity.ok(userDto);
-    }
-
-//    @PreAuthorize("hasRole('ROEL_ADMIN')")
-    @GetMapping
-    public ResponseEntity<List<UserDto>> findAllUserInfo() {
-        List<UserDto> userDtoList = userService.findAllUser();
-
-        return ResponseEntity.ok(userDtoList);
-    }
-
-//    @PreAuthorize("hasRole('ROEL_ADMIN')")
-    @GetMapping("/caretakers")
-    public ResponseEntity<List<UserDto>> findAllCaretakerInfo() {
-        List<UserDto> userDtoList = userService.findAllCaretaker();
-
-        return ResponseEntity.ok(userDtoList);
-    }
-
-//    @PreAuthorize("hasRole('ROEL_ADMIN')")
-    @GetMapping("/caregivers")
-    public ResponseEntity<List<UserDto>> findAllCaregiverInfo() {
-        List<UserDto> userDtoList = userService.findAllCaregiver();
-
-        return ResponseEntity.ok(userDtoList);
     }
 }

--- a/src/main/java/com/mednine/pillbuddy/domain/user/controller/UserController.java
+++ b/src/main/java/com/mednine/pillbuddy/domain/user/controller/UserController.java
@@ -3,12 +3,15 @@ package com.mednine.pillbuddy.domain.user.controller;
 import com.mednine.pillbuddy.domain.user.dto.JoinDto;
 import com.mednine.pillbuddy.domain.user.dto.LoginDto;
 import com.mednine.pillbuddy.domain.user.dto.UserDto;
+import com.mednine.pillbuddy.domain.user.dto.UserType;
 import com.mednine.pillbuddy.domain.user.service.UserService;
 import com.mednine.pillbuddy.global.jwt.JwtToken;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -48,5 +51,12 @@ public class UserController {
         JwtToken jwtToken = userService.reissueToken(bearerToken);
 
         return ResponseEntity.ok(jwtToken);
+    }
+
+    @GetMapping("/{userId}")
+    public ResponseEntity<UserDto> findUserInfo(@PathVariable Long userId, UserType userType) {
+        UserDto userDto = userService.findUser(userId, userType);
+
+        return ResponseEntity.ok(userDto);
     }
 }

--- a/src/main/java/com/mednine/pillbuddy/domain/user/controller/UserController.java
+++ b/src/main/java/com/mednine/pillbuddy/domain/user/controller/UserController.java
@@ -6,6 +6,7 @@ import com.mednine.pillbuddy.domain.user.dto.UserDto;
 import com.mednine.pillbuddy.domain.user.dto.UserType;
 import com.mednine.pillbuddy.domain.user.service.UserService;
 import com.mednine.pillbuddy.global.jwt.JwtToken;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
@@ -58,5 +59,13 @@ public class UserController {
         UserDto userDto = userService.findUser(userId, userType);
 
         return ResponseEntity.ok(userDto);
+    }
+
+//    @PreAuthorize("hasRole('ROEL_ADMIN')")
+    @GetMapping
+    public ResponseEntity<List<UserDto>> findAllUserInfo() {
+        List<UserDto> userDtoList = userService.findAllUser();
+
+        return ResponseEntity.ok(userDtoList);
     }
 }

--- a/src/main/java/com/mednine/pillbuddy/domain/user/controller/UserController.java
+++ b/src/main/java/com/mednine/pillbuddy/domain/user/controller/UserController.java
@@ -68,4 +68,20 @@ public class UserController {
 
         return ResponseEntity.ok(userDtoList);
     }
+
+//    @PreAuthorize("hasRole('ROEL_ADMIN')")
+    @GetMapping("/caretakers")
+    public ResponseEntity<List<UserDto>> findAllCaretakerInfo() {
+        List<UserDto> userDtoList = userService.findAllCaretaker();
+
+        return ResponseEntity.ok(userDtoList);
+    }
+
+//    @PreAuthorize("hasRole('ROEL_ADMIN')")
+    @GetMapping("/caregivers")
+    public ResponseEntity<List<UserDto>> findAllCaregiverInfo() {
+        List<UserDto> userDtoList = userService.findAllCaregiver();
+
+        return ResponseEntity.ok(userDtoList);
+    }
 }

--- a/src/main/java/com/mednine/pillbuddy/domain/user/dto/UserDto.java
+++ b/src/main/java/com/mednine/pillbuddy/domain/user/dto/UserDto.java
@@ -8,13 +8,22 @@ public class UserDto {
 
     private String userType;
     private String username;
+    private String loginId;
     private String email;
     private String phoneNumber;
+    private String imageUrl;
 
     public UserDto(User user) {
-        this.userType = user.getClass().getSimpleName();
+        this.userType = user.getClass().getSimpleName().toLowerCase();
         this.username = user.getUsername();
+        this.loginId = user.getLoginId();
         this.email = user.getEmail();
         this.phoneNumber = user.getPhoneNumber();
+
+        if (user.getImage() == null) {
+            this.imageUrl = "default.jpg";
+        } else {
+            this.imageUrl = user.getImage().getUrl();
+        }
     }
 }

--- a/src/main/java/com/mednine/pillbuddy/domain/user/dto/UserType.java
+++ b/src/main/java/com/mednine/pillbuddy/domain/user/dto/UserType.java
@@ -1,5 +1,12 @@
 package com.mednine.pillbuddy.domain.user.dto;
 
+import com.mednine.pillbuddy.domain.user.entity.User;
+
 public enum UserType {
-    CAREGIVER, CARETAKER
+    CAREGIVER, CARETAKER;
+
+    public static UserType from(User user) {
+        String userType = user.getClass().getSimpleName().toUpperCase();
+        return UserType.valueOf(userType);
+    }
 }

--- a/src/main/java/com/mednine/pillbuddy/domain/user/service/UserService.java
+++ b/src/main/java/com/mednine/pillbuddy/domain/user/service/UserService.java
@@ -103,6 +103,16 @@ public class UserService {
         return users.stream().map(UserDto::new).toList();
     }
 
+    public List<UserDto> findAllCaretaker() {
+        List<Caretaker> caretakers = caretakerRepository.findAll();
+        return caretakers.stream().map(UserDto::new).toList();
+    }
+
+    public List<UserDto> findAllCaregiver() {
+        List<Caregiver> caregivers = caregiverRepository.findAll();
+        return caregivers.stream().map(UserDto::new).toList();
+    }
+
     private void validateJoinInfo(JoinDto joinDto) {
         if (caregiverRepository.existsByLoginId(joinDto.getLoginId()) || caretakerRepository.existsByLoginId(joinDto.getLoginId())) {
             throw new PillBuddyCustomException(ErrorCode.USER_ALREADY_REGISTERED_LOGIN_ID);

--- a/src/main/java/com/mednine/pillbuddy/domain/user/service/UserService.java
+++ b/src/main/java/com/mednine/pillbuddy/domain/user/service/UserService.java
@@ -103,11 +103,13 @@ public class UserService {
         return users.stream().map(UserDto::new).toList();
     }
 
+    @Transactional(readOnly = true)
     public List<UserDto> findAllCaretaker() {
         List<Caretaker> caretakers = caretakerRepository.findAll();
         return caretakers.stream().map(UserDto::new).toList();
     }
 
+    @Transactional(readOnly = true)
     public List<UserDto> findAllCaregiver() {
         List<Caregiver> caregivers = caregiverRepository.findAll();
         return caregivers.stream().map(UserDto::new).toList();

--- a/src/main/java/com/mednine/pillbuddy/domain/user/service/UserService.java
+++ b/src/main/java/com/mednine/pillbuddy/domain/user/service/UserService.java
@@ -1,15 +1,20 @@
 package com.mednine.pillbuddy.domain.user.service;
 
+import com.mednine.pillbuddy.domain.user.caregiver.entity.Caregiver;
 import com.mednine.pillbuddy.domain.user.caregiver.repository.CaregiverRepository;
+import com.mednine.pillbuddy.domain.user.caretaker.entity.Caretaker;
 import com.mednine.pillbuddy.domain.user.caretaker.repository.CaretakerRepository;
 import com.mednine.pillbuddy.domain.user.dto.JoinDto;
 import com.mednine.pillbuddy.domain.user.dto.LoginDto;
 import com.mednine.pillbuddy.domain.user.dto.UserDto;
 import com.mednine.pillbuddy.domain.user.dto.UserType;
+import com.mednine.pillbuddy.domain.user.entity.User;
 import com.mednine.pillbuddy.global.exception.ErrorCode;
 import com.mednine.pillbuddy.global.exception.PillBuddyCustomException;
 import com.mednine.pillbuddy.global.jwt.JwtToken;
 import com.mednine.pillbuddy.global.jwt.JwtTokenProvider;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
@@ -83,6 +88,19 @@ public class UserService {
             case CARETAKER -> new UserDto(caretakerRepository.findById(userId)
                     .orElseThrow(() -> new PillBuddyCustomException(ErrorCode.USER_NOT_FOUND)));
         };
+    }
+
+    @Transactional(readOnly = true)
+    public List<UserDto> findAllUser() {
+        List<Caretaker> caretakers = caretakerRepository.findAll();
+        List<Caregiver> caregivers = caregiverRepository.findAll();
+
+        List<User> users = new ArrayList<>();
+
+        users.addAll(caretakers);
+        users.addAll(caregivers);
+
+        return users.stream().map(UserDto::new).toList();
     }
 
     private void validateJoinInfo(JoinDto joinDto) {

--- a/src/main/java/com/mednine/pillbuddy/domain/user/service/UserService.java
+++ b/src/main/java/com/mednine/pillbuddy/domain/user/service/UserService.java
@@ -1,20 +1,15 @@
 package com.mednine.pillbuddy.domain.user.service;
 
-import com.mednine.pillbuddy.domain.user.caregiver.entity.Caregiver;
 import com.mednine.pillbuddy.domain.user.caregiver.repository.CaregiverRepository;
-import com.mednine.pillbuddy.domain.user.caretaker.entity.Caretaker;
 import com.mednine.pillbuddy.domain.user.caretaker.repository.CaretakerRepository;
 import com.mednine.pillbuddy.domain.user.dto.JoinDto;
 import com.mednine.pillbuddy.domain.user.dto.LoginDto;
 import com.mednine.pillbuddy.domain.user.dto.UserDto;
 import com.mednine.pillbuddy.domain.user.dto.UserType;
-import com.mednine.pillbuddy.domain.user.entity.User;
 import com.mednine.pillbuddy.global.exception.ErrorCode;
 import com.mednine.pillbuddy.global.exception.PillBuddyCustomException;
 import com.mednine.pillbuddy.global.jwt.JwtToken;
 import com.mednine.pillbuddy.global.jwt.JwtTokenProvider;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
@@ -88,31 +83,6 @@ public class UserService {
             case CARETAKER -> new UserDto(caretakerRepository.findById(userId)
                     .orElseThrow(() -> new PillBuddyCustomException(ErrorCode.USER_NOT_FOUND)));
         };
-    }
-
-    @Transactional(readOnly = true)
-    public List<UserDto> findAllUser() {
-        List<Caretaker> caretakers = caretakerRepository.findAll();
-        List<Caregiver> caregivers = caregiverRepository.findAll();
-
-        List<User> users = new ArrayList<>();
-
-        users.addAll(caretakers);
-        users.addAll(caregivers);
-
-        return users.stream().map(UserDto::new).toList();
-    }
-
-    @Transactional(readOnly = true)
-    public List<UserDto> findAllCaretaker() {
-        List<Caretaker> caretakers = caretakerRepository.findAll();
-        return caretakers.stream().map(UserDto::new).toList();
-    }
-
-    @Transactional(readOnly = true)
-    public List<UserDto> findAllCaregiver() {
-        List<Caregiver> caregivers = caregiverRepository.findAll();
-        return caregivers.stream().map(UserDto::new).toList();
     }
 
     private void validateJoinInfo(JoinDto joinDto) {

--- a/src/main/java/com/mednine/pillbuddy/global/util/UploadUtils.java
+++ b/src/main/java/com/mednine/pillbuddy/global/util/UploadUtils.java
@@ -5,6 +5,7 @@ import com.mednine.pillbuddy.global.exception.PillBuddyCustomException;
 import jakarta.annotation.PostConstruct;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -42,7 +43,7 @@ public class UploadUtils {
         } catch (IOException e) {
             throw new PillBuddyCustomException(ErrorCode.PROFILE_NOT_SUPPORT_FILE_TYPE);
         }
-        return saveFileName;
+        return Paths.get(uploadPath, saveFileName).toString();
     }
 
     // 파일 이름에 특수 문자나 공백이 포함되어 있는 경우, 그 문자를 밑줄(_)로 대체
@@ -50,8 +51,8 @@ public class UploadUtils {
         return fileName.replaceAll(FILE_NAME_REGEX, FILE_NAME_REPLACEMENT);
     }
 
-    public void deleteFile(String fileName) {
-        File file = new File(uploadPath, fileName);
+    public void deleteFile(String filePath) {
+        File file = new File(filePath);
 
         if (file.exists() && !file.delete()) {
             throw new PillBuddyCustomException(ErrorCode.PROFILE_DELETE_FILE_FAIL);

--- a/src/test/java/com/mednine/pillbuddy/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/mednine/pillbuddy/domain/user/service/UserServiceTest.java
@@ -3,13 +3,20 @@ package com.mednine.pillbuddy.domain.user.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.mednine.pillbuddy.domain.user.caregiver.entity.Caregiver;
+import com.mednine.pillbuddy.domain.user.caregiver.repository.CaregiverRepository;
+import com.mednine.pillbuddy.domain.user.caretaker.entity.Caretaker;
+import com.mednine.pillbuddy.domain.user.caretaker.repository.CaretakerRepository;
 import com.mednine.pillbuddy.domain.user.dto.JoinDto;
 import com.mednine.pillbuddy.domain.user.dto.LoginDto;
 import com.mednine.pillbuddy.domain.user.dto.UserDto;
 import com.mednine.pillbuddy.domain.user.dto.UserType;
+import com.mednine.pillbuddy.domain.user.entity.Role;
+import com.mednine.pillbuddy.global.exception.ErrorCode;
 import com.mednine.pillbuddy.global.exception.PillBuddyCustomException;
 import com.mednine.pillbuddy.global.jwt.JwtToken;
 import com.mednine.pillbuddy.global.jwt.JwtTokenProvider;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,6 +35,24 @@ class UserServiceTest {
 
     @Autowired
     private JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    private CaretakerRepository caretakerRepository;
+
+    @Autowired
+    private CaregiverRepository caregiverRepository;
+
+    private Caretaker caretaker;
+
+    private Caregiver caregiver;
+
+    @BeforeEach
+    void setup() {
+        createCaretaker();
+        createCaregiver();
+        caretakerRepository.save(caretaker);
+        caregiverRepository.save(caregiver);
+    }
 
     @Test
     @DisplayName("JoinDto 를 통해 회원가입을 할 수 있다.")
@@ -174,5 +199,83 @@ class UserServiceTest {
         assertThatThrownBy(() -> userService.reissueToken(refreshToken))
                 .isInstanceOf(PillBuddyCustomException.class)
                 .hasMessage("유효하지 않은 JWT 토큰입니다.");
+    }
+
+    @Test
+    @DisplayName("사용자를 조회할 수 있다.")
+    void findCaretaker() {
+        // given
+        Long userId = caretaker.getId();
+        UserType userType = UserType.from(caretaker);
+
+        // when
+        UserDto userDto = userService.findUser(userId, userType);
+
+        // then
+        assertThat(userDto.getUsername()).isEqualTo(caretaker.getUsername());
+        assertThat(userDto.getPhoneNumber()).isEqualTo(caretaker.getPhoneNumber());
+        assertThat(userDto.getEmail()).isEqualTo(caretaker.getEmail());
+        assertThat(userDto.getUserType()).isEqualTo(String.valueOf(userType).toLowerCase());
+    }
+
+    @Test
+    @DisplayName("보호자를 조회할 수 있다.")
+    void findCaregiver() {
+        // given
+        Long userId = caregiver.getId();
+        UserType userType = UserType.from(caregiver);
+
+        // when
+        UserDto userDto = userService.findUser(userId, userType);
+
+        // then
+        assertThat(userDto.getUsername()).isEqualTo(caregiver.getUsername());
+        assertThat(userDto.getPhoneNumber()).isEqualTo(caregiver.getPhoneNumber());
+        assertThat(userDto.getEmail()).isEqualTo(caregiver.getEmail());
+        assertThat(userDto.getUserType()).isEqualTo(String.valueOf(userType).toLowerCase());
+    }
+
+    @Test
+    @DisplayName("등록되지 않은 사용자를 조회하면 PillBuddyCustomException 이 발생한다.")
+    void findCaretaker_with_invalid_caretaker() {
+        Long userId = 99999L;
+        UserType userType = UserType.CARETAKER;
+
+        assertThatThrownBy(() -> userService.findUser(userId, userType))
+                .isExactlyInstanceOf(PillBuddyCustomException.class)
+                .hasMessage(ErrorCode.USER_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("등록되지 않은 보호자를 조회하면 PillBuddyCustomException 이 발생한다.")
+    void findCaregiver_with_invalid_caregiver() {
+        Long userId = 99999L;
+        UserType userType = UserType.CAREGIVER;
+
+        assertThatThrownBy(() -> userService.findUser(userId, userType))
+                .isExactlyInstanceOf(PillBuddyCustomException.class)
+                .hasMessage(ErrorCode.USER_NOT_FOUND.getMessage());
+    }
+
+    private void createCaretaker() {
+        caretaker = Caretaker.builder()
+                .username("test-caretaker")
+                .loginId("test-loginId")
+                .password("test-password")
+                .email("test-email")
+                .phoneNumber("test-phoneNumber")
+                .role(Role.USER)
+                .build();
+    }
+
+    private void createCaregiver() {
+        caregiver = Caregiver.builder()
+                .username("test-caregiver")
+                .loginId("test-loginId")
+                .password("test-password")
+                .email("test-email")
+                .phoneNumber("test-phoneNumber")
+                .role(Role.USER)
+                .build();
     }
 }

--- a/src/test/java/com/mednine/pillbuddy/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/mednine/pillbuddy/domain/user/service/UserServiceTest.java
@@ -16,7 +16,6 @@ import com.mednine.pillbuddy.global.exception.ErrorCode;
 import com.mednine.pillbuddy.global.exception.PillBuddyCustomException;
 import com.mednine.pillbuddy.global.jwt.JwtToken;
 import com.mednine.pillbuddy.global.jwt.JwtTokenProvider;
-import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -256,63 +255,6 @@ class UserServiceTest {
         assertThatThrownBy(() -> userService.findUser(userId, userType))
                 .isExactlyInstanceOf(PillBuddyCustomException.class)
                 .hasMessage(ErrorCode.USER_NOT_FOUND.getMessage());
-    }
-
-    @Test
-    @DisplayName("모든 회원을 조회할 수 있다.")
-    void findAllUser() {
-        List<UserDto> userDtoList = userService.findAllUser();
-
-        assertThat(userDtoList).isNotEmpty();
-
-        // 사용자와 보호자 각각의 정보가 올바르게 반환되는지 확인
-        UserDto caretakerDto = userDtoList.stream()
-                .filter(dto -> dto.getUsername().equals("test-caretaker"))
-                .findFirst()
-                .orElseThrow();
-        assertThat(caretakerDto.getUsername()).isEqualTo(caretaker.getUsername());
-        assertThat(caretakerDto.getPhoneNumber()).isEqualTo(caretaker.getPhoneNumber());
-        assertThat(caretakerDto.getEmail()).isEqualTo(caretaker.getEmail());
-
-        UserDto caregiverDto = userDtoList.stream()
-                .filter(dto -> dto.getUsername().equals("test-caregiver"))
-                .findFirst()
-                .orElseThrow();
-        assertThat(caregiverDto.getUsername()).isEqualTo(caregiver.getUsername());
-        assertThat(caregiverDto.getPhoneNumber()).isEqualTo(caregiver.getPhoneNumber());
-        assertThat(caregiverDto.getEmail()).isEqualTo(caregiver.getEmail());
-    }
-
-    @Test
-    @DisplayName("모든 사용자를 조회할 수 있다.")
-    void findAllCaretaker() {
-        List<UserDto> userDtoList = userService.findAllCaretaker();
-
-        assertThat(userDtoList).isNotEmpty();
-
-        UserDto caretakerDto = userDtoList.stream()
-                .filter(dto -> dto.getUsername().equals("test-caretaker"))
-                .findFirst()
-                .orElseThrow();
-        assertThat(caretakerDto.getUsername()).isEqualTo(caretaker.getUsername());
-        assertThat(caretakerDto.getPhoneNumber()).isEqualTo(caretaker.getPhoneNumber());
-        assertThat(caretakerDto.getEmail()).isEqualTo(caretaker.getEmail());
-    }
-
-    @Test
-    @DisplayName("모든 보호자를 조회할 수 있다.")
-    void findAllCaregiver() {
-        List<UserDto> userDtoList = userService.findAllCaregiver();
-
-        assertThat(userDtoList).isNotEmpty();
-
-        UserDto caregiverDto = userDtoList.stream()
-                .filter(dto -> dto.getUsername().equals("test-caregiver"))
-                .findFirst()
-                .orElseThrow();
-        assertThat(caregiverDto.getUsername()).isEqualTo(caregiver.getUsername());
-        assertThat(caregiverDto.getPhoneNumber()).isEqualTo(caregiver.getPhoneNumber());
-        assertThat(caregiverDto.getEmail()).isEqualTo(caregiver.getEmail());
     }
 
     private void createCaretaker() {

--- a/src/test/java/com/mednine/pillbuddy/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/mednine/pillbuddy/domain/user/service/UserServiceTest.java
@@ -16,6 +16,7 @@ import com.mednine.pillbuddy.global.exception.ErrorCode;
 import com.mednine.pillbuddy.global.exception.PillBuddyCustomException;
 import com.mednine.pillbuddy.global.jwt.JwtToken;
 import com.mednine.pillbuddy.global.jwt.JwtTokenProvider;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -255,6 +256,63 @@ class UserServiceTest {
         assertThatThrownBy(() -> userService.findUser(userId, userType))
                 .isExactlyInstanceOf(PillBuddyCustomException.class)
                 .hasMessage(ErrorCode.USER_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("모든 회원을 조회할 수 있다.")
+    void findAllUser() {
+        List<UserDto> userDtoList = userService.findAllUser();
+
+        assertThat(userDtoList).isNotEmpty();
+
+        // 사용자와 보호자 각각의 정보가 올바르게 반환되는지 확인
+        UserDto caretakerDto = userDtoList.stream()
+                .filter(dto -> dto.getUsername().equals("test-caretaker"))
+                .findFirst()
+                .orElseThrow();
+        assertThat(caretakerDto.getUsername()).isEqualTo(caretaker.getUsername());
+        assertThat(caretakerDto.getPhoneNumber()).isEqualTo(caretaker.getPhoneNumber());
+        assertThat(caretakerDto.getEmail()).isEqualTo(caretaker.getEmail());
+
+        UserDto caregiverDto = userDtoList.stream()
+                .filter(dto -> dto.getUsername().equals("test-caregiver"))
+                .findFirst()
+                .orElseThrow();
+        assertThat(caregiverDto.getUsername()).isEqualTo(caregiver.getUsername());
+        assertThat(caregiverDto.getPhoneNumber()).isEqualTo(caregiver.getPhoneNumber());
+        assertThat(caregiverDto.getEmail()).isEqualTo(caregiver.getEmail());
+    }
+
+    @Test
+    @DisplayName("모든 사용자를 조회할 수 있다.")
+    void findAllCaretaker() {
+        List<UserDto> userDtoList = userService.findAllCaretaker();
+
+        assertThat(userDtoList).isNotEmpty();
+
+        UserDto caretakerDto = userDtoList.stream()
+                .filter(dto -> dto.getUsername().equals("test-caretaker"))
+                .findFirst()
+                .orElseThrow();
+        assertThat(caretakerDto.getUsername()).isEqualTo(caretaker.getUsername());
+        assertThat(caretakerDto.getPhoneNumber()).isEqualTo(caretaker.getPhoneNumber());
+        assertThat(caretakerDto.getEmail()).isEqualTo(caretaker.getEmail());
+    }
+
+    @Test
+    @DisplayName("모든 보호자를 조회할 수 있다.")
+    void findAllCaregiver() {
+        List<UserDto> userDtoList = userService.findAllCaregiver();
+
+        assertThat(userDtoList).isNotEmpty();
+
+        UserDto caregiverDto = userDtoList.stream()
+                .filter(dto -> dto.getUsername().equals("test-caregiver"))
+                .findFirst()
+                .orElseThrow();
+        assertThat(caregiverDto.getUsername()).isEqualTo(caregiver.getUsername());
+        assertThat(caregiverDto.getPhoneNumber()).isEqualTo(caregiver.getPhoneNumber());
+        assertThat(caregiverDto.getEmail()).isEqualTo(caregiver.getEmail());
     }
 
     private void createCaretaker() {

--- a/src/test/java/com/mednine/pillbuddy/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/mednine/pillbuddy/domain/user/service/UserServiceTest.java
@@ -44,7 +44,7 @@ class UserServiceTest {
         assertThat(userDto.getUsername()).isEqualTo("newUser");
         assertThat(userDto.getPhoneNumber()).isEqualTo("010-1112-2221");
         assertThat(userDto.getEmail()).isEqualTo("new@gmail.com");
-        assertThat(userDto.getUserType()).isEqualTo("Caretaker");
+        assertThat(userDto.getUserType()).isEqualTo("caretaker");
     }
 
     @Test

--- a/src/test/java/com/mednine/pillbuddy/global/util/UploadUtilsTest.java
+++ b/src/test/java/com/mednine/pillbuddy/global/util/UploadUtilsTest.java
@@ -32,13 +32,13 @@ public class UploadUtilsTest {
         MockMultipartFile mockFile = new MockMultipartFile("file", "testFile.jpg", "image/jpeg", new byte[]{1, 2, 3, 4});
 
         // When
-        String savedFileName = uploadUtils.upload(mockFile);
+        String savedFilePath = uploadUtils.upload(mockFile);
 
         // Then
-        File uploadedFile = new File(tempDir.toFile(), savedFileName);
+        File uploadedFile = new File(savedFilePath);
         assertThat(uploadedFile.exists()).isTrue();
         assertThat(uploadedFile.getName()).contains("testFile");
-        assertThat(savedFileName).contains("_");
+        assertThat(savedFilePath).contains("_");
     }
 
     @Test

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -32,3 +32,14 @@ jwt:
 
 file:
   path: test-upload
+
+openApi:
+  dataType: json
+  serviceKey: ${LOCAL_SERVICE_KEY}
+  callbackUrl: http://apis.data.go.kr/1471000/DrbEasyDrugInfoService/getDrbEasyDrugList
+
+sms:
+  api-key: ${API_KEY}
+  api-secret-key: ${API_SECRET}
+  domain: https://api.coolsms.co.kr
+  from-number: 01040765951


### PR DESCRIPTION
## 👩‍💻작업 내용
- [x] DTO 클래스 구현 
- [x] 사용자 및 보호자 조회 기능 구현
- [x] 모든 회원 리스트 조회 기능 구현
- [x] 모든 사용자 조회 기능 구현
- [x] 모든 보호자 조회 기능 구현
- [x] 테스트 코드 작성

## 💬리뷰 요구 사항
회원 조회 시, 회원의 이미지 url 을 이미지 테이블에서 가져올 때, fetch 조인을 사용해야 할지 고민이 있었습니다.. (아직도 잘 모르겠음)
또한, 이미지를 등록하지 않은 회원에게는 default.jpg 의 url 을 가져오도록 구현했습니다 ! 


+) 사용자 입장에서 사용자가 등록한 보호자들을 조회 및 등록한 약 정보들 조회, 보호자 입장에서 보호자가 등록한 사용자들을 조회 등 조회 메서드를 추가로 작성해야 할 것 같은데 어떻게 생각하실까요??
