### PR TITLE
40: [FEAT] 사용자 기능 API 구현, 약 복용 여부 기록

### DIFF
--- a/src/main/java/com/mednine/pillbuddy/domain/record/dto/RecordDTO.java
+++ b/src/main/java/com/mednine/pillbuddy/domain/record/dto/RecordDTO.java
@@ -11,7 +11,6 @@ import java.time.LocalDateTime;
 @Setter
 @AllArgsConstructor
 public class RecordDTO {
-
     private Long recordId;
     private LocalDateTime date;
     private String medicationName;

--- a/src/main/java/com/mednine/pillbuddy/domain/record/entity/Record.java
+++ b/src/main/java/com/mednine/pillbuddy/domain/record/entity/Record.java
@@ -25,7 +25,7 @@ public class Record extends BaseTimeEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "taken", nullable = false)
-    private Taken taken = Taken.UNTAKEN; // 생성 시, 기본 값을 UNTAKEN으로 성정
+    private Taken taken = Taken.UNTAKEN; // 기본 값을 UNTAKEN으로 성정
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_medication_id")

--- a/src/main/java/com/mednine/pillbuddy/domain/record/entity/Record.java
+++ b/src/main/java/com/mednine/pillbuddy/domain/record/entity/Record.java
@@ -2,23 +2,10 @@ package com.mednine.pillbuddy.domain.record.entity;
 
 import com.mednine.pillbuddy.domain.userMedication.entity.UserMedication;
 import com.mednine.pillbuddy.global.entity.BaseTimeEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
+import lombok.*;
+
 import java.time.LocalDateTime;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "record")
@@ -38,7 +25,7 @@ public class Record extends BaseTimeEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "taken", nullable = false)
-    private Taken taken;
+    private Taken taken = Taken.UNTAKEN; // 생성 시, 기본 값을 UNTAKEN으로 성정
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_medication_id")
@@ -47,5 +34,9 @@ public class Record extends BaseTimeEntity {
     public void changeUserMedication(UserMedication userMedication) {
         this.userMedication = userMedication;
         userMedication.getRecords().add(this);
+    }
+
+    public void takeMedication(Taken taken) {
+        this.taken = taken;
     }
 }

--- a/src/main/java/com/mednine/pillbuddy/domain/record/repository/RecordRepository.java
+++ b/src/main/java/com/mednine/pillbuddy/domain/record/repository/RecordRepository.java
@@ -3,4 +3,5 @@ package com.mednine.pillbuddy.domain.record.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RecordRepository extends JpaRepository<Record, Long> {
+
 }

--- a/src/main/java/com/mednine/pillbuddy/domain/record/repository/RecordRepository.java
+++ b/src/main/java/com/mednine/pillbuddy/domain/record/repository/RecordRepository.java
@@ -1,0 +1,6 @@
+package com.mednine.pillbuddy.domain.record.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RecordRepository extends JpaRepository<Record, Long> {
+}

--- a/src/main/java/com/mednine/pillbuddy/domain/record/service/RecordService.java
+++ b/src/main/java/com/mednine/pillbuddy/domain/record/service/RecordService.java
@@ -3,5 +3,6 @@ package com.mednine.pillbuddy.domain.record.service;
 import com.mednine.pillbuddy.domain.record.dto.RecordDTO;
 
 public interface RecordService {
+
     RecordDTO modifyTaken(Long userMedicationId, Long recordId);
 }

--- a/src/main/java/com/mednine/pillbuddy/domain/record/service/RecordService.java
+++ b/src/main/java/com/mednine/pillbuddy/domain/record/service/RecordService.java
@@ -1,0 +1,7 @@
+package com.mednine.pillbuddy.domain.record.service;
+
+import com.mednine.pillbuddy.domain.record.dto.RecordDTO;
+
+public interface RecordService {
+    RecordDTO modifyTaken(Long userMedicationId, Long recordId);
+}

--- a/src/main/java/com/mednine/pillbuddy/domain/record/service/RecordServiceImpl.java
+++ b/src/main/java/com/mednine/pillbuddy/domain/record/service/RecordServiceImpl.java
@@ -1,0 +1,37 @@
+package com.mednine.pillbuddy.domain.record.service;
+
+import com.mednine.pillbuddy.domain.record.dto.RecordDTO;
+import com.mednine.pillbuddy.domain.record.entity.Record;
+import com.mednine.pillbuddy.domain.record.entity.Taken;
+import com.mednine.pillbuddy.domain.userMedication.entity.UserMedication;
+import com.mednine.pillbuddy.domain.userMedication.repository.UserMedicationRepository;
+import com.mednine.pillbuddy.global.exception.ErrorCode;
+import com.mednine.pillbuddy.global.exception.PillBuddyCustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class RecordServiceImpl implements RecordService {
+
+    private final UserMedicationRepository userMedicationRepository;
+
+    @Override
+    @Transactional
+    public RecordDTO modifyTaken(Long userMedicationId, Long recordId) {
+        UserMedication userMedication = userMedicationRepository.findById(userMedicationId).orElse(null);
+
+        Record record = userMedication.getRecords().stream()
+                .filter(x -> x.getId().equals(recordId))
+                .findFirst().orElseThrow(() -> new PillBuddyCustomException(ErrorCode.RECORD_NOT_FOUND));
+
+        if (record.getTaken().equals(Taken.UNTAKEN)) {
+            record.takeMedication(Taken.TAKEN);
+        } else if (record.getTaken().equals(Taken.TAKEN)) {
+            throw new PillBuddyCustomException(ErrorCode.RECORD_NOT_VALID);
+        }
+
+        return new RecordDTO(record);
+    }
+}

--- a/src/main/java/com/mednine/pillbuddy/domain/record/service/RecordServiceImpl.java
+++ b/src/main/java/com/mednine/pillbuddy/domain/record/service/RecordServiceImpl.java
@@ -20,7 +20,8 @@ public class RecordServiceImpl implements RecordService {
     @Override
     @Transactional
     public RecordDTO modifyTaken(Long userMedicationId, Long recordId) {
-        UserMedication userMedication = userMedicationRepository.findById(userMedicationId).orElse(null);
+        UserMedication userMedication = userMedicationRepository.findById(userMedicationId)
+                .orElseThrow(() -> new PillBuddyCustomException(ErrorCode.MEDICATION_NOT_FOUND));
 
         Record record = userMedication.getRecords().stream()
                 .filter(x -> x.getId().equals(recordId))

--- a/src/main/java/com/mednine/pillbuddy/domain/user/caretaker/controller/CaretakerController.java
+++ b/src/main/java/com/mednine/pillbuddy/domain/user/caretaker/controller/CaretakerController.java
@@ -20,9 +20,9 @@ import java.util.Map;
 @RequestMapping("/api/caretakers")
 public class CaretakerController {
 
+    private final RecordService recordService;
     private final CaretakerService caretakerService;
     private final UserMedicationService userMedicationService;
-    private final RecordService recordService;
 
     @PostMapping("/{caretakerId}/caregivers/{caregiverId}")
     public ResponseEntity<CaretakerCaregiverDTO> addCaregiver(@PathVariable Long caretakerId, @PathVariable Long caregiverId) {

--- a/src/main/java/com/mednine/pillbuddy/domain/user/caretaker/controller/CaretakerController.java
+++ b/src/main/java/com/mednine/pillbuddy/domain/user/caretaker/controller/CaretakerController.java
@@ -1,6 +1,7 @@
 package com.mednine.pillbuddy.domain.user.caretaker.controller;
 
 import com.mednine.pillbuddy.domain.record.dto.RecordDTO;
+import com.mednine.pillbuddy.domain.record.service.RecordService;
 import com.mednine.pillbuddy.domain.user.caretaker.dto.CaretakerCaregiverDTO;
 import com.mednine.pillbuddy.domain.user.caretaker.service.CaretakerService;
 import com.mednine.pillbuddy.domain.userMedication.service.UserMedicationService;
@@ -21,6 +22,7 @@ public class CaretakerController {
 
     private final CaretakerService caretakerService;
     private final UserMedicationService userMedicationService;
+    private final RecordService recordService;
 
     @PostMapping("/{caretakerId}/caregivers/{caregiverId}")
     public ResponseEntity<CaretakerCaregiverDTO> addCaregiver(@PathVariable Long caretakerId, @PathVariable Long caregiverId) {
@@ -41,6 +43,13 @@ public class CaretakerController {
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
         List<RecordDTO> records = userMedicationService.getUserMedicationRecordsByDate(caretakerId, date.atStartOfDay());
         return ResponseEntity.ok(records);
+    }
+
+    @PatchMapping("/user-medications/{userMedicationId}/records/{recordId}")
+    public ResponseEntity<RecordDTO> updateMedicationByTaken(@PathVariable Long userMedicationId,
+                                                             @PathVariable Long recordId) {
+        RecordDTO savedRecordDTO = recordService.modifyTaken(userMedicationId, recordId);
+        return ResponseEntity.ok(savedRecordDTO);
     }
 }
 

--- a/src/main/java/com/mednine/pillbuddy/global/exception/ErrorCode.java
+++ b/src/main/java/com/mednine/pillbuddy/global/exception/ErrorCode.java
@@ -65,7 +65,11 @@ public enum ErrorCode {
     NETWORK_ERROR(SERVICE_UNAVAILABLE, "네트워크 통신 중 오류가 발생했습니다."),
 
     MESSAGE_SEND_FAILED(BAD_REQUEST, "메시지 전송에 실패했습니다."),
-    NOTIFICATION_NOT_FOUND(NOT_FOUND, "알람 정보를 찾을 수 없습니다.");
+    NOTIFICATION_NOT_FOUND(NOT_FOUND, "알람 정보를 찾을 수 없습니다."),
+
+    RECORD_NOT_FOUND(NOT_FOUND, "저장된 기록을 찾을 수 없습니다"),
+    RECORD_NOT_REGISTERED(CONFLICT, "기록 저장에 실패 했습니다"),
+    RECORD_NOT_VALID(CONFLICT, "이미 복용한 약 정보 기록입니다");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/mednine/pillbuddy/global/exception/ErrorCode.java
+++ b/src/main/java/com/mednine/pillbuddy/global/exception/ErrorCode.java
@@ -69,7 +69,7 @@ public enum ErrorCode {
 
     RECORD_NOT_FOUND(NOT_FOUND, "저장된 기록을 찾을 수 없습니다"),
     RECORD_NOT_REGISTERED(CONFLICT, "기록 저장에 실패 했습니다"),
-    RECORD_NOT_VALID(CONFLICT, "이미 복용한 약 정보 기록입니다");
+    RECORD_NOT_VALID(CONFLICT, "이미 복용된 약 정보 기록입니다");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/test/java/com/mednine/pillbuddy/domain/record/service/RecordServiceImplTest.java
+++ b/src/test/java/com/mednine/pillbuddy/domain/record/service/RecordServiceImplTest.java
@@ -11,7 +11,6 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 @SpringBootTest
 class RecordServiceImplTest {
-
     @Autowired
     private RecordService recordService;
 

--- a/src/test/java/com/mednine/pillbuddy/domain/record/service/RecordServiceImplTest.java
+++ b/src/test/java/com/mednine/pillbuddy/domain/record/service/RecordServiceImplTest.java
@@ -1,0 +1,31 @@
+package com.mednine.pillbuddy.domain.record.service;
+
+import com.mednine.pillbuddy.domain.record.dto.RecordDTO;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@SpringBootTest
+class RecordServiceImplTest {
+
+    @Autowired
+    private RecordService recordService;
+
+    @Test
+    @Transactional
+    @DisplayName("사용자 약 복용 여부 기록 서비스 레이어 테스트")
+    public void updateMedicationTaken() {
+        Long userMedicationId = 2L;
+        Long recordId = 2L;
+
+        RecordDTO modifyTaken = recordService.modifyTaken(userMedicationId, recordId);
+
+        assertThat(modifyTaken).isNotNull();
+        assertThat(modifyTaken.getRecordId()).isEqualTo(2);
+        assertThat(modifyTaken.getTaken()).isEqualTo("TAKEN");
+    }
+}

--- a/src/test/java/com/mednine/pillbuddy/domain/user/caretaker/controller/CaretakerControllerTest.java
+++ b/src/test/java/com/mednine/pillbuddy/domain/user/caretaker/controller/CaretakerControllerTest.java
@@ -76,7 +76,6 @@ public class CaretakerControllerTest {
         ResponseEntity<RecordDTO> recordDTOResponseEntity = caretakerController.updateMedicationByTaken(userMedicationId, recordId);
 
         assertThat(recordDTOResponseEntity).isNotNull();
-        assertThat(recordDTOResponseEntity.getBody()).isNotNull();
         assertThat(recordDTOResponseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(recordDTOResponseEntity.getBody().getTaken()).isEqualTo("TAKEN");
     }

--- a/src/test/java/com/mednine/pillbuddy/domain/user/caretaker/controller/CaretakerControllerTest.java
+++ b/src/test/java/com/mednine/pillbuddy/domain/user/caretaker/controller/CaretakerControllerTest.java
@@ -65,4 +65,19 @@ public class CaretakerControllerTest {
         assertThat(recordDTO.getMedicationName()).isEqualTo("Aspirin"); // 약 이름 검증
         assertThat(recordDTO.getTaken()).isEqualTo("TAKEN"); // 복용 여부 검증
     }
+
+    @Test
+    @Transactional
+    @DisplayName("사용자의 약 복용 여부 수정 테스트")
+    public void updateMedicationByTaken() {
+        Long userMedicationId = 2L;
+        Long recordId = 2L;
+
+        ResponseEntity<RecordDTO> recordDTOResponseEntity = caretakerController.updateMedicationByTaken(userMedicationId, recordId);
+
+        assertThat(recordDTOResponseEntity).isNotNull();
+        assertThat(recordDTOResponseEntity.getBody()).isNotNull();
+        assertThat(recordDTOResponseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(recordDTOResponseEntity.getBody().getTaken()).isEqualTo("TAKEN");
+    }
 }


### PR DESCRIPTION
## 👩‍💻작업 내용
사용자 기능 중 약 복용 여부 기록 구현
1. record 엔티티에서 레코드 생성 시, 기본 값을 복용하지 않음으로 설정
2. 섭취 여부를 바꾸기 위해 setter 추가
3. 서비스 로직을 위한 컨트롤러 수정 및 서비스, 레포지토리 레이어 추가
4. 에러 코드 일부 추가
5. 테스트 코드 작성

## 💬리뷰 요구 사항
병합 과정에서 충돌이 발생하여 해결한다고 pr이 많이 늦어졌습니다..

처음 약 정보에 대한 기록 생성 시, 디폴트 값으로 untaken이 들어갑니다
이후 복용 여부를 선택하면 taken으로 바뀌게 되고, 이미 복용하여 taken인 기록에 대해 다시 복용 여부를 선택하게 되면 "이미 복용한 약 정보 기록입니다"라는 문구의 예외를 던지게 만들었습니다

오타 및 로직 오류 검토 요망

## 📃참고 자료
