### PR TITLE
 40: [FEAT] 약 정보 기록 초기값 세팅 및 복용 기록 수정

### DIFF
--- a/src/main/java/com/mednine/pillbuddy/domain/record/dto/RecordDTO.java
+++ b/src/main/java/com/mednine/pillbuddy/domain/record/dto/RecordDTO.java
@@ -11,7 +11,6 @@ import java.time.LocalDateTime;
 @Setter
 @AllArgsConstructor
 public class RecordDTO {
-
     private Long recordId;
     private LocalDateTime date;
     private String medicationName;

--- a/src/main/java/com/mednine/pillbuddy/domain/record/dto/RecordDTO.java
+++ b/src/main/java/com/mednine/pillbuddy/domain/record/dto/RecordDTO.java
@@ -1,15 +1,15 @@
 package com.mednine.pillbuddy.domain.record.dto;
 
 import com.mednine.pillbuddy.domain.record.entity.Record;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
 @Getter
 @Setter
 @AllArgsConstructor
+@NoArgsConstructor
+@Builder
 public class RecordDTO {
     private Long recordId;
     private LocalDateTime date;

--- a/src/main/java/com/mednine/pillbuddy/domain/record/entity/Record.java
+++ b/src/main/java/com/mednine/pillbuddy/domain/record/entity/Record.java
@@ -25,7 +25,7 @@ public class Record extends BaseTimeEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "taken", nullable = false)
-    private Taken taken = Taken.UNTAKEN; // 생성 시, 기본 값을 UNTAKEN으로 성정
+    private Taken taken = Taken.UNTAKEN; // 기본 값을 UNTAKEN으로 성정
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_medication_id")

--- a/src/main/java/com/mednine/pillbuddy/domain/record/entity/Record.java
+++ b/src/main/java/com/mednine/pillbuddy/domain/record/entity/Record.java
@@ -2,23 +2,10 @@ package com.mednine.pillbuddy.domain.record.entity;
 
 import com.mednine.pillbuddy.domain.userMedication.entity.UserMedication;
 import com.mednine.pillbuddy.global.entity.BaseTimeEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
+import lombok.*;
+
 import java.time.LocalDateTime;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "record")
@@ -38,7 +25,7 @@ public class Record extends BaseTimeEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "taken", nullable = false)
-    private Taken taken;
+    private Taken taken = Taken.UNTAKEN; // 생성 시, 기본 값을 UNTAKEN으로 성정
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_medication_id")
@@ -47,5 +34,9 @@ public class Record extends BaseTimeEntity {
     public void changeUserMedication(UserMedication userMedication) {
         this.userMedication = userMedication;
         userMedication.getRecords().add(this);
+    }
+
+    public void takeMedication(Taken taken) {
+        this.taken = taken;
     }
 }

--- a/src/main/java/com/mednine/pillbuddy/domain/record/entity/Record.java
+++ b/src/main/java/com/mednine/pillbuddy/domain/record/entity/Record.java
@@ -25,7 +25,7 @@ public class Record extends BaseTimeEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "taken", nullable = false)
-    private Taken taken = Taken.UNTAKEN; // 기본 값을 UNTAKEN으로 성정
+    private Taken taken;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_medication_id")
@@ -36,7 +36,7 @@ public class Record extends BaseTimeEntity {
         userMedication.getRecords().add(this);
     }
 
-    public void takeMedication(Taken taken) {
-        this.taken = taken;
+    public void takeMedication() {
+        this.taken = Taken.TAKEN;
     }
 }

--- a/src/main/java/com/mednine/pillbuddy/domain/record/repository/RecordRepository.java
+++ b/src/main/java/com/mednine/pillbuddy/domain/record/repository/RecordRepository.java
@@ -3,4 +3,5 @@ package com.mednine.pillbuddy.domain.record.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RecordRepository extends JpaRepository<Record, Long> {
+
 }

--- a/src/main/java/com/mednine/pillbuddy/domain/record/repository/RecordRepository.java
+++ b/src/main/java/com/mednine/pillbuddy/domain/record/repository/RecordRepository.java
@@ -1,7 +1,7 @@
 package com.mednine.pillbuddy.domain.record.repository;
 
+import com.mednine.pillbuddy.domain.record.entity.Record;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RecordRepository extends JpaRepository<Record, Long> {
-
 }

--- a/src/main/java/com/mednine/pillbuddy/domain/record/repository/RecordRepository.java
+++ b/src/main/java/com/mednine/pillbuddy/domain/record/repository/RecordRepository.java
@@ -1,0 +1,6 @@
+package com.mednine.pillbuddy.domain.record.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RecordRepository extends JpaRepository<Record, Long> {
+}

--- a/src/main/java/com/mednine/pillbuddy/domain/record/service/RecordService.java
+++ b/src/main/java/com/mednine/pillbuddy/domain/record/service/RecordService.java
@@ -3,5 +3,6 @@ package com.mednine.pillbuddy.domain.record.service;
 import com.mednine.pillbuddy.domain.record.dto.RecordDTO;
 
 public interface RecordService {
+
     RecordDTO modifyTaken(Long userMedicationId, Long recordId);
 }

--- a/src/main/java/com/mednine/pillbuddy/domain/record/service/RecordService.java
+++ b/src/main/java/com/mednine/pillbuddy/domain/record/service/RecordService.java
@@ -1,0 +1,7 @@
+package com.mednine.pillbuddy.domain.record.service;
+
+import com.mednine.pillbuddy.domain.record.dto.RecordDTO;
+
+public interface RecordService {
+    RecordDTO modifyTaken(Long userMedicationId, Long recordId);
+}

--- a/src/main/java/com/mednine/pillbuddy/domain/record/service/RecordService.java
+++ b/src/main/java/com/mednine/pillbuddy/domain/record/service/RecordService.java
@@ -3,6 +3,6 @@ package com.mednine.pillbuddy.domain.record.service;
 import com.mednine.pillbuddy.domain.record.dto.RecordDTO;
 
 public interface RecordService {
-
     RecordDTO modifyTaken(Long userMedicationId, Long recordId);
+    RecordDTO registerRecord(Long userMedicationId);
 }

--- a/src/main/java/com/mednine/pillbuddy/domain/record/service/RecordServiceImpl.java
+++ b/src/main/java/com/mednine/pillbuddy/domain/record/service/RecordServiceImpl.java
@@ -1,0 +1,37 @@
+package com.mednine.pillbuddy.domain.record.service;
+
+import com.mednine.pillbuddy.domain.record.dto.RecordDTO;
+import com.mednine.pillbuddy.domain.record.entity.Record;
+import com.mednine.pillbuddy.domain.record.entity.Taken;
+import com.mednine.pillbuddy.domain.userMedication.entity.UserMedication;
+import com.mednine.pillbuddy.domain.userMedication.repository.UserMedicationRepository;
+import com.mednine.pillbuddy.global.exception.ErrorCode;
+import com.mednine.pillbuddy.global.exception.PillBuddyCustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class RecordServiceImpl implements RecordService {
+
+    private final UserMedicationRepository userMedicationRepository;
+
+    @Override
+    @Transactional
+    public RecordDTO modifyTaken(Long userMedicationId, Long recordId) {
+        UserMedication userMedication = userMedicationRepository.findById(userMedicationId).orElse(null);
+
+        Record record = userMedication.getRecords().stream()
+                .filter(x -> x.getId().equals(recordId))
+                .findFirst().orElseThrow(() -> new PillBuddyCustomException(ErrorCode.RECORD_NOT_FOUND));
+
+        if (record.getTaken().equals(Taken.UNTAKEN)) {
+            record.takeMedication(Taken.TAKEN);
+        } else if (record.getTaken().equals(Taken.TAKEN)) {
+            throw new PillBuddyCustomException(ErrorCode.RECORD_NOT_VALID);
+        }
+
+        return new RecordDTO(record);
+    }
+}

--- a/src/main/java/com/mednine/pillbuddy/domain/record/service/RecordServiceImpl.java
+++ b/src/main/java/com/mednine/pillbuddy/domain/record/service/RecordServiceImpl.java
@@ -3,6 +3,7 @@ package com.mednine.pillbuddy.domain.record.service;
 import com.mednine.pillbuddy.domain.record.dto.RecordDTO;
 import com.mednine.pillbuddy.domain.record.entity.Record;
 import com.mednine.pillbuddy.domain.record.entity.Taken;
+import com.mednine.pillbuddy.domain.record.repository.RecordRepository;
 import com.mednine.pillbuddy.domain.userMedication.entity.UserMedication;
 import com.mednine.pillbuddy.domain.userMedication.repository.UserMedicationRepository;
 import com.mednine.pillbuddy.global.exception.ErrorCode;
@@ -11,11 +12,31 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+
 @Service
 @RequiredArgsConstructor
 public class RecordServiceImpl implements RecordService {
 
     private final UserMedicationRepository userMedicationRepository;
+    private final RecordRepository recordRepository;
+
+    @Override
+    @Transactional
+    public RecordDTO registerRecord(Long userMedicationId) {
+        UserMedication userMedication = userMedicationRepository.findById(userMedicationId).orElseThrow(
+                () -> new PillBuddyCustomException(ErrorCode.MEDICATION_NOT_FOUND)
+        );
+
+        Record record = Record.builder()
+                .userMedication(userMedication)
+                .date(LocalDateTime.now())
+                .taken(Taken.UNTAKEN)
+                .build();
+
+        Record savedRecord = recordRepository.save(record);
+        return new RecordDTO(savedRecord);
+    }
 
     @Override
     @Transactional
@@ -28,9 +49,9 @@ public class RecordServiceImpl implements RecordService {
                 .findFirst().orElseThrow(() -> new PillBuddyCustomException(ErrorCode.RECORD_NOT_FOUND));
 
         if (record.getTaken().equals(Taken.UNTAKEN)) {
-            record.takeMedication(Taken.TAKEN);
+            record.takeMedication();
         } else if (record.getTaken().equals(Taken.TAKEN)) {
-            throw new PillBuddyCustomException(ErrorCode.RECORD_NOT_VALID);
+            throw new PillBuddyCustomException(ErrorCode.RECORD_ALREADY_TAKEN);
         }
 
         return new RecordDTO(record);

--- a/src/main/java/com/mednine/pillbuddy/domain/record/service/RecordServiceImpl.java
+++ b/src/main/java/com/mednine/pillbuddy/domain/record/service/RecordServiceImpl.java
@@ -20,7 +20,8 @@ public class RecordServiceImpl implements RecordService {
     @Override
     @Transactional
     public RecordDTO modifyTaken(Long userMedicationId, Long recordId) {
-        UserMedication userMedication = userMedicationRepository.findById(userMedicationId).orElse(null);
+        UserMedication userMedication = userMedicationRepository.findById(userMedicationId)
+                .orElseThrow(() -> new PillBuddyCustomException(ErrorCode.MEDICATION_NOT_FOUND));
 
         Record record = userMedication.getRecords().stream()
                 .filter(x -> x.getId().equals(recordId))

--- a/src/main/java/com/mednine/pillbuddy/domain/user/caretaker/controller/CaretakerController.java
+++ b/src/main/java/com/mednine/pillbuddy/domain/user/caretaker/controller/CaretakerController.java
@@ -20,9 +20,9 @@ import java.util.Map;
 @RequestMapping("/api/caretakers")
 public class CaretakerController {
 
+    private final RecordService recordService;
     private final CaretakerService caretakerService;
     private final UserMedicationService userMedicationService;
-    private final RecordService recordService;
 
     @PostMapping("/{caretakerId}/caregivers/{caregiverId}")
     public ResponseEntity<CaretakerCaregiverDTO> addCaregiver(@PathVariable Long caretakerId, @PathVariable Long caregiverId) {

--- a/src/main/java/com/mednine/pillbuddy/domain/user/caretaker/controller/CaretakerController.java
+++ b/src/main/java/com/mednine/pillbuddy/domain/user/caretaker/controller/CaretakerController.java
@@ -1,6 +1,7 @@
 package com.mednine.pillbuddy.domain.user.caretaker.controller;
 
 import com.mednine.pillbuddy.domain.record.dto.RecordDTO;
+import com.mednine.pillbuddy.domain.record.service.RecordService;
 import com.mednine.pillbuddy.domain.user.caretaker.dto.CaretakerCaregiverDTO;
 import com.mednine.pillbuddy.domain.user.caretaker.service.CaretakerService;
 import com.mednine.pillbuddy.domain.userMedication.service.UserMedicationService;
@@ -21,6 +22,7 @@ public class CaretakerController {
 
     private final CaretakerService caretakerService;
     private final UserMedicationService userMedicationService;
+    private final RecordService recordService;
 
     @PostMapping("/{caretakerId}/caregivers/{caregiverId}")
     public ResponseEntity<CaretakerCaregiverDTO> addCaregiver(@PathVariable Long caretakerId, @PathVariable Long caregiverId) {
@@ -41,6 +43,13 @@ public class CaretakerController {
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
         List<RecordDTO> records = userMedicationService.getUserMedicationRecordsByDate(caretakerId, date.atStartOfDay());
         return ResponseEntity.ok(records);
+    }
+
+    @PatchMapping("/user-medications/{userMedicationId}/records/{recordId}")
+    public ResponseEntity<RecordDTO> updateMedicationByTaken(@PathVariable Long userMedicationId,
+                                                             @PathVariable Long recordId) {
+        RecordDTO savedRecordDTO = recordService.modifyTaken(userMedicationId, recordId);
+        return ResponseEntity.ok(savedRecordDTO);
     }
 }
 

--- a/src/main/java/com/mednine/pillbuddy/domain/user/caretaker/controller/CaretakerController.java
+++ b/src/main/java/com/mednine/pillbuddy/domain/user/caretaker/controller/CaretakerController.java
@@ -45,9 +45,15 @@ public class CaretakerController {
         return ResponseEntity.ok(records);
     }
 
-    @PatchMapping("/user-medications/{userMedicationId}/records/{recordId}")
-    public ResponseEntity<RecordDTO> updateMedicationByTaken(@PathVariable Long userMedicationId,
-                                                             @PathVariable Long recordId) {
+    @PostMapping("/user-medications/{userMedicationId}/records")
+    public ResponseEntity<RecordDTO> addRecord(@PathVariable Long userMedicationId) {
+        RecordDTO savedRecordDTO = recordService.registerRecord(userMedicationId);
+        return ResponseEntity.ok(savedRecordDTO);
+    }
+
+    @PutMapping("/user-medications/{userMedicationId}/records/{recordId}")
+    public ResponseEntity<RecordDTO> updateRecord(@PathVariable Long userMedicationId,
+                                                  @PathVariable Long recordId) {
         RecordDTO savedRecordDTO = recordService.modifyTaken(userMedicationId, recordId);
         return ResponseEntity.ok(savedRecordDTO);
     }

--- a/src/main/java/com/mednine/pillbuddy/global/exception/ErrorCode.java
+++ b/src/main/java/com/mednine/pillbuddy/global/exception/ErrorCode.java
@@ -69,7 +69,7 @@ public enum ErrorCode {
 
     RECORD_NOT_FOUND(NOT_FOUND, "저장된 기록을 찾을 수 없습니다"),
     RECORD_NOT_REGISTERED(CONFLICT, "기록 저장에 실패 했습니다"),
-    RECORD_NOT_VALID(CONFLICT, "이미 복용된 약 정보 기록입니다");
+    RECORD_ALREADY_TAKEN(CONFLICT, "이미 복용된 약 정보 기록입니다");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/mednine/pillbuddy/global/exception/ErrorCode.java
+++ b/src/main/java/com/mednine/pillbuddy/global/exception/ErrorCode.java
@@ -65,7 +65,11 @@ public enum ErrorCode {
     NETWORK_ERROR(SERVICE_UNAVAILABLE, "네트워크 통신 중 오류가 발생했습니다."),
 
     MESSAGE_SEND_FAILED(BAD_REQUEST, "메시지 전송에 실패했습니다."),
-    NOTIFICATION_NOT_FOUND(NOT_FOUND, "알람 정보를 찾을 수 없습니다.");
+    NOTIFICATION_NOT_FOUND(NOT_FOUND, "알람 정보를 찾을 수 없습니다."),
+
+    RECORD_NOT_FOUND(NOT_FOUND, "저장된 기록을 찾을 수 없습니다"),
+    RECORD_NOT_REGISTERED(CONFLICT, "기록 저장에 실패 했습니다"),
+    RECORD_NOT_VALID(CONFLICT, "이미 복용한 약 정보 기록입니다");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/mednine/pillbuddy/global/exception/ErrorCode.java
+++ b/src/main/java/com/mednine/pillbuddy/global/exception/ErrorCode.java
@@ -69,7 +69,7 @@ public enum ErrorCode {
 
     RECORD_NOT_FOUND(NOT_FOUND, "저장된 기록을 찾을 수 없습니다"),
     RECORD_NOT_REGISTERED(CONFLICT, "기록 저장에 실패 했습니다"),
-    RECORD_NOT_VALID(CONFLICT, "이미 복용한 약 정보 기록입니다");
+    RECORD_NOT_VALID(CONFLICT, "이미 복용된 약 정보 기록입니다");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/test/java/com/mednine/pillbuddy/domain/record/service/RecordServiceImplTest.java
+++ b/src/test/java/com/mednine/pillbuddy/domain/record/service/RecordServiceImplTest.java
@@ -11,7 +11,6 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 @SpringBootTest
 class RecordServiceImplTest {
-
     @Autowired
     private RecordService recordService;
 

--- a/src/test/java/com/mednine/pillbuddy/domain/record/service/RecordServiceImplTest.java
+++ b/src/test/java/com/mednine/pillbuddy/domain/record/service/RecordServiceImplTest.java
@@ -1,0 +1,31 @@
+package com.mednine.pillbuddy.domain.record.service;
+
+import com.mednine.pillbuddy.domain.record.dto.RecordDTO;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@SpringBootTest
+class RecordServiceImplTest {
+
+    @Autowired
+    private RecordService recordService;
+
+    @Test
+    @Transactional
+    @DisplayName("사용자 약 복용 여부 기록 서비스 레이어 테스트")
+    public void updateMedicationTaken() {
+        Long userMedicationId = 2L;
+        Long recordId = 2L;
+
+        RecordDTO modifyTaken = recordService.modifyTaken(userMedicationId, recordId);
+
+        assertThat(modifyTaken).isNotNull();
+        assertThat(modifyTaken.getRecordId()).isEqualTo(2);
+        assertThat(modifyTaken.getTaken()).isEqualTo("TAKEN");
+    }
+}

--- a/src/test/java/com/mednine/pillbuddy/domain/record/service/RecordServiceImplTest.java
+++ b/src/test/java/com/mednine/pillbuddy/domain/record/service/RecordServiceImplTest.java
@@ -27,4 +27,15 @@ class RecordServiceImplTest {
         assertThat(modifyTaken.getRecordId()).isEqualTo(2);
         assertThat(modifyTaken.getTaken()).isEqualTo("TAKEN");
     }
+
+    @Test
+    @Transactional
+    @DisplayName("사용자 약 정보 기록 등록")
+    public void registerRecord() {
+        Long userMedicationId = 1L;
+
+        RecordDTO recordDTO = recordService.registerRecord(userMedicationId);
+        assertThat(recordDTO).isNotNull();
+        assertThat(recordDTO.getTaken()).isEqualTo("UNTAKEN");
+    }
 }

--- a/src/test/java/com/mednine/pillbuddy/domain/user/caretaker/controller/CaretakerControllerTest.java
+++ b/src/test/java/com/mednine/pillbuddy/domain/user/caretaker/controller/CaretakerControllerTest.java
@@ -76,7 +76,6 @@ public class CaretakerControllerTest {
         ResponseEntity<RecordDTO> recordDTOResponseEntity = caretakerController.updateMedicationByTaken(userMedicationId, recordId);
 
         assertThat(recordDTOResponseEntity).isNotNull();
-        assertThat(recordDTOResponseEntity.getBody()).isNotNull();
         assertThat(recordDTOResponseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(recordDTOResponseEntity.getBody().getTaken()).isEqualTo("TAKEN");
     }

--- a/src/test/java/com/mednine/pillbuddy/domain/user/caretaker/controller/CaretakerControllerTest.java
+++ b/src/test/java/com/mednine/pillbuddy/domain/user/caretaker/controller/CaretakerControllerTest.java
@@ -73,10 +73,22 @@ public class CaretakerControllerTest {
         Long userMedicationId = 2L;
         Long recordId = 2L;
 
-        ResponseEntity<RecordDTO> recordDTOResponseEntity = caretakerController.updateMedicationByTaken(userMedicationId, recordId);
+        ResponseEntity<RecordDTO> recordDTOResponseEntity = caretakerController.updateRecord(userMedicationId, recordId);
 
         assertThat(recordDTOResponseEntity).isNotNull();
         assertThat(recordDTOResponseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(recordDTOResponseEntity.getBody().getTaken()).isEqualTo("TAKEN");
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("사용자의 약 정보에 대한 기록 등록")
+    public void addRecord() {
+        Long userMedicationId = 2L;
+
+        ResponseEntity<RecordDTO> recordDTOResponseEntity = caretakerController.addRecord(userMedicationId);
+        assertThat(recordDTOResponseEntity).isNotNull();
+        assertThat(recordDTOResponseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(recordDTOResponseEntity.getBody().getTaken()).isEqualTo("UNTAKEN");
     }
 }

--- a/src/test/java/com/mednine/pillbuddy/domain/user/caretaker/controller/CaretakerControllerTest.java
+++ b/src/test/java/com/mednine/pillbuddy/domain/user/caretaker/controller/CaretakerControllerTest.java
@@ -65,4 +65,19 @@ public class CaretakerControllerTest {
         assertThat(recordDTO.getMedicationName()).isEqualTo("Aspirin"); // 약 이름 검증
         assertThat(recordDTO.getTaken()).isEqualTo("TAKEN"); // 복용 여부 검증
     }
+
+    @Test
+    @Transactional
+    @DisplayName("사용자의 약 복용 여부 수정 테스트")
+    public void updateMedicationByTaken() {
+        Long userMedicationId = 2L;
+        Long recordId = 2L;
+
+        ResponseEntity<RecordDTO> recordDTOResponseEntity = caretakerController.updateMedicationByTaken(userMedicationId, recordId);
+
+        assertThat(recordDTOResponseEntity).isNotNull();
+        assertThat(recordDTOResponseEntity.getBody()).isNotNull();
+        assertThat(recordDTOResponseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(recordDTOResponseEntity.getBody().getTaken()).isEqualTo("TAKEN");
+    }
 }


### PR DESCRIPTION
## 👩‍💻작업 내용
사용자의 약 정보 기록에 대한 record 초기값을 untaken으로 세팅하고, 실제 약을 복용할 시 taken으로 변경 및 taken으로 변경된 값을 다시 변경하려 할 경우 "이미 복용한 약 입니다"라는 예외처리 메세지를 던지는 로직 구성

1. 컨트롤러 레이어 수정
2. 서비스 레이어 수정
3. 에러코드 코드 추가
4. dto, entity 리팩토링
5. 테스트 코드 추가, 성공
 
@추가 사항
record entity에서 date 필드를 빼서 조금 더 깔끔하게 만들 수 있을 것 같은데 엮어있는 부분이 조금 있어서 시간이 된다면 수정하고 안된다면 그대로 유지해야 할 것 같음... 
 
## 💬리뷰 요구 사항
오타 및 로직 오류 

## 📃참고 자료
