### PR TITLE
46:[REFACTOR] 약 정보 검색

### DIFF
--- a/src/main/java/com/mednine/pillbuddy/domain/medicationApi/controller/MedicationApiController.java
+++ b/src/main/java/com/mednine/pillbuddy/domain/medicationApi/controller/MedicationApiController.java
@@ -6,19 +6,23 @@ import com.mednine.pillbuddy.domain.medicationApi.dto.MedicationForm;
 import com.mednine.pillbuddy.domain.medicationApi.service.MedicationApiService;
 import com.mednine.pillbuddy.global.exception.ErrorCode;
 import com.mednine.pillbuddy.global.exception.PillBuddyCustomException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
-
-@RestController @RequiredArgsConstructor
-@RequestMapping("/api/search") @Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/search")
+@Slf4j
 public class MedicationApiController {
-
     private final MedicationApiService medicationApiService;
 
     @GetMapping
@@ -26,25 +30,19 @@ public class MedicationApiController {
                                         BindingResult bindingResult,
                                         @RequestParam(defaultValue = "1") int pageNo,
                                         @RequestParam(defaultValue = "10") int numOfRows) {
+
         if (bindingResult.hasErrors()) {
             throw new PillBuddyCustomException(ErrorCode.REQUIRED_VALUE);
         }
-
-        //db에 데이터가 있다면 바로 반환
+        //DB에 레코드가 있다면 DB에서 레코드 반환
         Page<MedicationDTO> allByName = medicationApiService.findAllByName(medicationForm.getItemName(),pageNo-1,numOfRows);
         if (!allByName.isEmpty()) {
-            if (pageNo > allByName.getTotalPages()) throw new PillBuddyCustomException(ErrorCode.OUT_OF_PAGE);
             return new JsonForm((int)allByName.getTotalElements(),pageNo,allByName.getTotalPages(),allByName.getContent());
         }
-
-        //없다면 totalcount 개수만큼 api에 요청하여 db에 저장후 반환
-        String[] onlyTotalCount = medicationApiService.jsonToString(medicationForm,0,0);
-        int totalCount = Integer.parseInt(onlyTotalCount[1]);
-        String[] realResult = medicationApiService.jsonToString(medicationForm, pageNo, totalCount);
-        List<MedicationDTO> medicationDTOS = medicationApiService.StringToDTOs(realResult[0]);
+        //DB에 레코드가 없다면 외부API 통신을 통해 DB에 레코드를 저장한 후 레코드 반환
+        List<MedicationDTO> medicationDTOS = medicationApiService.createDto(medicationForm);
         medicationApiService.saveMedication(medicationDTOS);
-        allByName = medicationApiService.findAllByName(medicationForm.getItemName(),pageNo-1,numOfRows);
-        if (pageNo > allByName.getTotalPages()) throw new PillBuddyCustomException(ErrorCode.OUT_OF_PAGE);  // 페이지 초과 시 예외 발생
+        allByName = medicationApiService.findAllByName(medicationForm.getItemName(), pageNo - 1, numOfRows);
         return new JsonForm((int)allByName.getTotalElements(), pageNo,allByName.getTotalPages(), allByName.getContent());
     }
 }

--- a/src/main/java/com/mednine/pillbuddy/domain/medicationApi/dto/MedicationDTO.java
+++ b/src/main/java/com/mednine/pillbuddy/domain/medicationApi/dto/MedicationDTO.java
@@ -29,5 +29,4 @@ public class MedicationDTO {
 
     @JsonProperty("itemImage")
     private String itemImagePath;
-
 }

--- a/src/main/java/com/mednine/pillbuddy/domain/medicationApi/dto/MedicationForm.java
+++ b/src/main/java/com/mednine/pillbuddy/domain/medicationApi/dto/MedicationForm.java
@@ -11,6 +11,4 @@ public class MedicationForm {
     private String itemName;
 
     private String itemSeq;
-
-
 }

--- a/src/main/java/com/mednine/pillbuddy/domain/medicationApi/service/MedicationApiService.java
+++ b/src/main/java/com/mednine/pillbuddy/domain/medicationApi/service/MedicationApiService.java
@@ -1,8 +1,6 @@
 package com.mednine.pillbuddy.domain.medicationApi.service;
 
-import static com.mednine.pillbuddy.global.exception.ErrorCode.ERROR_CONNECTION;
 import static com.mednine.pillbuddy.global.exception.ErrorCode.MEDICATION_NOT_FOUND;
-import static com.mednine.pillbuddy.global.exception.ErrorCode.NETWORK_ERROR;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -13,12 +11,7 @@ import com.mednine.pillbuddy.domain.medicationApi.dto.MedicationForm;
 import com.mednine.pillbuddy.domain.medicationApi.entity.Medication;
 import com.mednine.pillbuddy.domain.medicationApi.repository.MedicationApiRepository;
 import com.mednine.pillbuddy.global.exception.PillBuddyCustomException;
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.net.HttpURLConnection;
-import java.net.URL;
+import java.net.URI;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -26,18 +19,24 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class MedicationApiService {
+
     private final MedicationApiRepository medicationApiRepository;
     private final ObjectMapper objectMapper;
+    private final RestTemplate restTemplate;
+
 
     @Value("${openApi.dataType}")
     private String dataType;
@@ -46,8 +45,26 @@ public class MedicationApiService {
     @Value("${openApi.callbackUrl}")
     private String callbackUrl;
 
+    public List<MedicationDTO> createDto(MedicationForm medicationForm) {
+
+        String JsonToString = restTemplate.getForObject(createUrl(medicationForm, 0),
+                String.class);
+        try {
+            Integer totalCount = objectMapper.readValue(objectMapper.readTree(JsonToString).path("body").path("totalCount").toString(), Integer.class);
+            JsonToString = restTemplate.getForObject(createUrl(medicationForm, totalCount),
+                    String.class);
+
+            JsonNode rootNode = objectMapper.readTree(JsonToString);
+            JsonNode itemsNode = rootNode.path("body").path("items");
+            return objectMapper.readValue(itemsNode.toString(), new TypeReference<>(){});
+
+        } catch (JsonProcessingException | IllegalArgumentException e) {
+            throw new PillBuddyCustomException(MEDICATION_NOT_FOUND);
+        }
+    }
+
     @Transactional(readOnly = true)
-    public Page<MedicationDTO> findAllByName(String itemName,int pageNo,int numOfRows) {
+    public Page<MedicationDTO> findAllByName(String itemName, int pageNo, int numOfRows) {
         PageRequest pageRequest = PageRequest.of(pageNo,numOfRows, Sort.by(Sort.Direction.ASC, "itemSeq"));
         Page<Medication> allByItemNameLike = medicationApiRepository.findAllByItemNameLike(itemName,pageRequest);
         return allByItemNameLike.map(Medication::changeDTO);
@@ -55,52 +72,14 @@ public class MedicationApiService {
 
     @Transactional
     public void saveMedication(List<MedicationDTO> medicationDTOList){
-        List<Medication> medicationList = medicationDTOList.stream().map(Medication::createMedication).collect(Collectors.toList());
+        List<Medication> medicationList = medicationDTOList.stream().map(Medication::createMedication).collect(
+                Collectors.toList());
         medicationApiRepository.saveAll(medicationList);
     }
 
-    public String[] jsonToString(MedicationForm medicationForm, int pageNo, int numOfRows) {
-
-        HttpURLConnection urlConnection = null;
-        InputStream stream;
-        String result;
-        String[] results = new String[2];
-        try {
-            URL url = new URL(createUrl(medicationForm,pageNo,numOfRows));
-            urlConnection = (HttpURLConnection) url.openConnection();
-            stream = getNetworkConnection(urlConnection);
-            result = readStreamToString(stream);
-            Integer totalCount = objectMapper.readValue(objectMapper.readTree(result).path("body").path("totalCount").toString(), Integer.class);
-            results[1] = String.valueOf(totalCount);
-            if (stream != null) {
-                stream.close();
-            }
-
-        } catch (IOException e) {
-            throw new PillBuddyCustomException(NETWORK_ERROR);
-        } finally {
-            if (urlConnection != null) {
-                urlConnection.disconnect();
-            }
-        }
-        results[0] = result;
-        return results;
-    }
-    public List<MedicationDTO> StringToDTOs(String jsonData) {
-        try {
-            JsonNode rootNode = objectMapper.readTree(jsonData);
-            JsonNode itemsNode = rootNode.path("body").path("items");
-            return objectMapper.readValue(itemsNode.toString(), new TypeReference<>(){});
-
-        } catch (JsonProcessingException e) {
-            throw new PillBuddyCustomException(MEDICATION_NOT_FOUND);
-        }
-    }
-
-
-    private String createUrl(MedicationForm medicationForm, int pageNo, int numOfRows) {
+    private URI createUrl(MedicationForm medicationForm, int numOfRows) {
         String encodedItemName = stringEncoding(medicationForm.getItemName());
-        String url = callbackUrl + "?serviceKey=" + serviceKey + "&type=" + dataType + "&itemName=" + encodedItemName+"&pageNo="+pageNo+"&numOfRows="+numOfRows;
+        String url = callbackUrl + "?serviceKey=" + serviceKey + "&type=" + dataType + "&itemName=" + encodedItemName+"&pageNo=1"+"&numOfRows="+numOfRows;
         if (medicationForm.getEntpName() != null) {
             String encodedEntpName = stringEncoding(medicationForm.getEntpName());
             url += "&entpName=" + encodedEntpName;
@@ -110,40 +89,19 @@ public class MedicationApiService {
             url += "&itemSeq=" + encodedItemSeq;
         }
         log.info("generateUrl={}",url);
-        return url;
+        return URI.create(url);
     }
 
     private String stringEncoding(String parameter){
-        return URLEncoder.encode(parameter,StandardCharsets.UTF_8);
+        return URLEncoder.encode(parameter, StandardCharsets.UTF_8);
     }
 
-    private InputStream getNetworkConnection(HttpURLConnection urlConnection)  {
-        try {
-            urlConnection.setConnectTimeout(3000);
-            urlConnection.setReadTimeout(3000);
-            urlConnection.setRequestMethod("GET");
-            urlConnection.setDoInput(true);
-
-            if(urlConnection.getResponseCode() != HttpURLConnection.HTTP_OK) {
-                throw new PillBuddyCustomException(ERROR_CONNECTION);
-            }
-            return urlConnection.getInputStream();
-        } catch (IOException e) {
-            throw new PillBuddyCustomException(ERROR_CONNECTION);
+    @Component
+    static class RestTemplateConfig{
+        @Bean
+        RestTemplate restTemplate() {
+            return new RestTemplate();
         }
     }
-
-    private String readStreamToString(InputStream stream){
-        StringBuilder result = new StringBuilder();
-        try (BufferedReader br = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8))) {
-            String readLine;
-            while ((readLine = br.readLine()) != null) {
-                result.append(readLine).append("\n\r");
-            }
-        } catch (IOException e) {
-            throw new PillBuddyCustomException(NETWORK_ERROR);
-        }
-        return result.toString();
-    }
-
 }
+

--- a/src/test/java/com/mednine/pillbuddy/domain/medicationApi/service/MedicationApiServiceTest.java
+++ b/src/test/java/com/mednine/pillbuddy/domain/medicationApi/service/MedicationApiServiceTest.java
@@ -3,6 +3,7 @@ package com.mednine.pillbuddy.domain.medicationApi.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mednine.pillbuddy.domain.medicationApi.dto.MedicationDTO;
 import com.mednine.pillbuddy.domain.medicationApi.dto.MedicationForm;
 import com.mednine.pillbuddy.domain.medicationApi.entity.Medication;
@@ -10,117 +11,90 @@ import com.mednine.pillbuddy.domain.medicationApi.repository.MedicationApiReposi
 import com.mednine.pillbuddy.global.exception.PillBuddyCustomException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.orm.jpa.JpaSystemException;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
 
 @SpringBootTest
+@Transactional
 class MedicationApiServiceTest {
 
     @Autowired
     private MedicationApiService medicationApiService;
-    @Autowired
-    private MedicationApiRepository medicationApiRepository;
+    @MockBean
+    RestTemplate restTemplate;
     @BeforeEach
     void setUp() {
         List<Medication> medicationList = new ArrayList<>();
         MedicationDTO medicationDTO1 = new MedicationDTO();
         medicationDTO1.setItemSeq("199000505");
         medicationDTO1.setItemName("아스피린1");
-
         MedicationDTO medicationDTO2 = new MedicationDTO();
         medicationDTO2.setItemSeq("199000506");
         medicationDTO2.setItemName("아스피린2");
         medicationList.add(Medication.createMedication(medicationDTO1));
         medicationList.add(Medication.createMedication(medicationDTO2));
-        medicationApiRepository.saveAll(medicationList);
+        medicationApiService.saveMedication(medicationList.stream().map(Medication::changeDTO).collect(Collectors.toList()));
+        String jsonToString = "{\"header\":{\"resultCode\":\"00\",\"resultMsg\":\"NORMAL SERVICE.\"},\"body\":{\"pageNo\":1,\"totalCount\":1,\"numOfRows\":10,\"items\":[{\"entpName\":\"한국존슨앤드존슨판매(유)\",\"itemName\":\"어린이타이레놀산160밀리그램(아세트아미노펜)\",\"itemSeq\":\"202005623\",\"depositMethodQesitm\":\"실온에서 보관하십시오.\\n\\n어린이의 손이 닿지 않는 곳에 보관하십시오.\\n\",\"itemImage\":null,\"bizrno\":\"1068649891\"}]}}";
+        Mockito.when(restTemplate.getForObject(Mockito.argThat(uri -> uri.toString().contains("%ED%83%80%EC%9D%B4%EB%A0%88%EB%86%80")),Mockito.eq(String.class))).thenReturn(jsonToString);
     }
 
 
     @Test
-    void testJsonToString_Success(){
+    @DisplayName("JSON을 파싱해 DB에 저장되고, 조회시 저장된 DTO가 반환돼야 한다.")
+    void testCreateDto_Success(){
         MedicationForm medicationForm = new MedicationForm();
-        medicationForm.setItemName("아스피린");
-        String[] strings = medicationApiService.jsonToString(medicationForm, 1, 1);
-        assertThat(strings[0]).contains("NORMAL SERVICE");
-        assertThat(strings[1]).isEqualTo("52");
+        medicationForm.setItemName("타이레놀");
+        List<MedicationDTO> dto = medicationApiService.createDto(medicationForm);
+        assertThat(dto.size()).isEqualTo(1);
+        assertThat(dto.get(0).getItemName()).isEqualTo("어린이타이레놀산160밀리그램(아세트아미노펜)");
+        medicationApiService.saveMedication(dto);
+        Page<MedicationDTO> findDto = medicationApiService.findAllByName("타이레놀", 0, 10);
+        assertThat(findDto.getContent().size()).isEqualTo(1);
+        assertThat(findDto.getContent().get(0).getItemName()).isEqualTo("어린이타이레놀산160밀리그램(아세트아미노펜)");
+        assertThat(findDto.getTotalPages()).isEqualTo(1);
     }
 
-
     @Test
-    void testJsonToString_Fail(){
+    @DisplayName("없는 약 이름을 입력했을 때 예외가 발생해야 한다.")
+    void testCreateDto_Fail() {
         MedicationForm medicationForm = new MedicationForm();
-        medicationForm.setItemName("afadfsfa");
-        String[] strings = medicationApiService.jsonToString(medicationForm, 1, 1);
-        assertThatThrownBy(() -> medicationApiService.StringToDTOs(strings[0])).isInstanceOf(PillBuddyCustomException.class);
+        medicationForm.setItemName("asdasd");
+        assertThatThrownBy(() -> medicationApiService.createDto(medicationForm)).isInstanceOf(
+                PillBuddyCustomException.class);
     }
 
 
     @Test
-    void stringToDTOs_success(){
-        MedicationForm form = new MedicationForm();
-        form.setItemName("아스피린");
-        int numOfRows = 10;
-        String[] strings = medicationApiService.jsonToString(form, 1, numOfRows);
-        List<MedicationDTO> medicationDTOS = medicationApiService.StringToDTOs(strings[0]);
-        assertThat(medicationDTOS.size()).isLessThanOrEqualTo(numOfRows);
-        for (MedicationDTO medicationDTO : medicationDTOS) {
-            assertThat(medicationDTO.getItemName()).contains("아스피린");
-        }
-    }
-    @Test
-    void stringToDTOs_Fail(){
-        MedicationForm medicationForm = new MedicationForm();
-        medicationForm.setItemName("afadfsfa");
-        String[] strings = medicationApiService.jsonToString(medicationForm, 1, 1);
-        assertThatThrownBy(() -> medicationApiService.StringToDTOs(strings[0])).isInstanceOf(PillBuddyCustomException.class);
-
-    }
-
-    @Test
+    @DisplayName("저장된 데이터가 조회돼야 한다.")
     void save_Success() {
-
-        PageRequest pageRequest = PageRequest.of(0,2, Sort.by(Sort.Direction.ASC, "itemSeq"));
-        Page<Medication> allByName = medicationApiRepository.findAllByItemNameLike("아스피린",pageRequest);
+        Page<MedicationDTO> allByName = medicationApiService.findAllByName("아스피린",0,10);
         assertThat(allByName.getTotalElements()).isEqualTo(2);
         assertThat(allByName.getTotalPages()).isEqualTo(1);
-
     }
+
     @Test
+    @DisplayName("필수값을 입력하지 않은 데이터는 저장되지 않아야 한다.")
     void save_fail_noName(){
-        List<Medication> medicationList = new ArrayList<>();
+        List<MedicationDTO> medicationDTOList = new ArrayList<>();
         MedicationDTO medicationDTO1 = new MedicationDTO();
         MedicationDTO medicationDTO2 = new MedicationDTO();
-        medicationList.add(Medication.createMedication(medicationDTO1));
-        medicationList.add(Medication.createMedication(medicationDTO2));
-        assertThatThrownBy(() -> medicationApiRepository.saveAll(medicationList)).isInstanceOf(
+        medicationDTOList.add(medicationDTO1);
+        medicationDTOList.add(medicationDTO2);
+        assertThatThrownBy(() -> medicationApiService.saveMedication(medicationDTOList)).isInstanceOf(
                 JpaSystemException.class);
     }
-    @Test
-    void save_fail_duplicationId(){
-        List<Medication> medicationList = new ArrayList<>();
-        MedicationDTO medicationDTO1 = new MedicationDTO();
-        MedicationDTO medicationDTO2 = new MedicationDTO();
-        medicationList.add(Medication.createMedication(medicationDTO1));
-        medicationList.add(Medication.createMedication(medicationDTO2));
-        medicationDTO1.setItemSeq("19990999");
-        medicationDTO2.setItemSeq("19990999");
-        assertThatThrownBy(() -> medicationApiRepository.saveAll(medicationList)).isInstanceOf(
-                JpaSystemException.class);
-    }
-
-    @Test
-    void findByName_fail() {
-        PageRequest pageRequest = PageRequest.of(0,2, Sort.by(Sort.Direction.ASC, "itemSeq"));
-        Page<Medication> allByName = medicationApiRepository.findAllByItemNameLike("sadasd",pageRequest);
-        assertThat(allByName).isEmpty();
-        assertThat(allByName.getTotalElements()).isEqualTo(0);
-        assertThat(allByName.getTotalPages()).isEqualTo(0);
-    }
-
 }

--- a/src/test/java/com/mednine/pillbuddy/domain/medicationApi/service/MedicationApiServiceTest.java
+++ b/src/test/java/com/mednine/pillbuddy/domain/medicationApi/service/MedicationApiServiceTest.java
@@ -3,11 +3,9 @@ package com.mednine.pillbuddy.domain.medicationApi.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mednine.pillbuddy.domain.medicationApi.dto.MedicationDTO;
 import com.mednine.pillbuddy.domain.medicationApi.dto.MedicationForm;
 import com.mednine.pillbuddy.domain.medicationApi.entity.Medication;
-import com.mednine.pillbuddy.domain.medicationApi.repository.MedicationApiRepository;
 import com.mednine.pillbuddy.global.exception.PillBuddyCustomException;
 import java.util.ArrayList;
 import java.util.List;
@@ -15,16 +13,12 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Sort;
 import org.springframework.orm.jpa.JpaSystemException;
-import org.springframework.test.annotation.Rollback;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
 


### PR DESCRIPTION
## 👩‍💻작업 내용
HttpURLConnection과 stream을 RestTemplate로 변경하였습니다
RestTemplate를 Mock으로 구현하여 테스트코드에서 외부API 서버의 의존도를 없앴습니다.
## 💬리뷰 요구 사항
3차 프로젝트에 시간이 남는다는 강사님 말씀에 따라서 3차 프로젝트에는 스케줄러를 활용한 DB에 저장된 레코드와 외부API의 데이터를 정해진 시간에 동기화하는 작업을 해볼 예정입니다. 
서버에 2번 연결하는 문제는 해결하지 못했습니다. totalCount가 필수적으로 필요해 이부분에 대한 생각이 깊어지네요 이 부분 역시 3차 프로젝트에 작업해보지 않을까 생각중입니다.
현재까지의 생각해본 구현 방향은 
1. 첫 통신때 100개의 데이터를 가져온다
2. totalCount가 100개 초과라면 API와 필요한 연결 최소값을 구해 그 만큼 반복해 연결한다
입니다.
## 📃참고 자료
RestTemplate 인증키 인코딩 문제 해결 : https://velog.io/@cco2416/%EC%A1%B8%EC%97%85%ED%94%84%EB%A1%9C%EC%A0%9D%ED%8A%B8%EA%B3%B5%EA%B3%B5%EB%8D%B0%EC%9D%B4%ED%84%B0-%ED%8F%AC%ED%84%B8-service-key-is-not-registered-error-%ED%95%B4%EA%B2%B0-%EB%B0%A9%EB%B2%95

RestTemplate 전반적인 사용법 : https://adjh54.tistory.com/234
https://velog.io/@jmjmjmz732002/Springboot-Open-API%EB%A5%BC-%ED%99%9C%EC%9A%A9%ED%95%9C-Spring-%EC%84%9C%EB%B2%84-%EA%B0%9C%EB%B0%9C%ED%95%98%EA%B8%B0