### PR TITLE
69:[FEAT] 리프레시 토큰 관리 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'net.nurigo:sdk:4.2.7'
 
+    // Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
     // JWT
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'

--- a/src/main/java/com/mednine/pillbuddy/domain/user/controller/AuthController.java
+++ b/src/main/java/com/mednine/pillbuddy/domain/user/controller/AuthController.java
@@ -1,0 +1,52 @@
+package com.mednine.pillbuddy.domain.user.controller;
+
+import com.mednine.pillbuddy.domain.user.dto.JoinDto;
+import com.mednine.pillbuddy.domain.user.dto.LoginDto;
+import com.mednine.pillbuddy.domain.user.dto.UserDto;
+import com.mednine.pillbuddy.domain.user.service.AuthService;
+import com.mednine.pillbuddy.global.jwt.JwtToken;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/join")
+    public ResponseEntity<UserDto> join(@Validated @RequestBody JoinDto joinDto) {
+        UserDto userDto = authService.join(joinDto);
+
+        return ResponseEntity.ok(userDto);
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<JwtToken> login(@RequestBody LoginDto loginDto) {
+        JwtToken jwtToken = authService.login(loginDto);
+
+        return ResponseEntity.ok(jwtToken);
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout() {
+        authService.logout();
+
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/reissue-token")
+    public ResponseEntity<JwtToken> reissueToken(@RequestHeader(HttpHeaders.AUTHORIZATION) String bearerToken) {
+        JwtToken jwtToken = authService.reissueToken(bearerToken);
+
+        return ResponseEntity.ok(jwtToken);
+    }
+}

--- a/src/main/java/com/mednine/pillbuddy/domain/user/controller/UserController.java
+++ b/src/main/java/com/mednine/pillbuddy/domain/user/controller/UserController.java
@@ -1,24 +1,18 @@
 package com.mednine.pillbuddy.domain.user.controller;
 
-import com.mednine.pillbuddy.domain.user.dto.JoinDto;
-import com.mednine.pillbuddy.domain.user.dto.LoginDto;
 import com.mednine.pillbuddy.domain.user.dto.UserDto;
 import com.mednine.pillbuddy.domain.user.dto.UserPasswordUpdateDto;
 import com.mednine.pillbuddy.domain.user.dto.UserType;
 import com.mednine.pillbuddy.domain.user.dto.UserUpdateDto;
 import com.mednine.pillbuddy.domain.user.service.UserService;
-import com.mednine.pillbuddy.global.jwt.JwtToken;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 

--- a/src/main/java/com/mednine/pillbuddy/domain/user/controller/UserController.java
+++ b/src/main/java/com/mednine/pillbuddy/domain/user/controller/UserController.java
@@ -29,34 +29,6 @@ public class UserController {
 
     private final UserService userService;
 
-    @PostMapping("/join")
-    public ResponseEntity<UserDto> join(@Validated @RequestBody JoinDto joinDto) {
-        UserDto userDto = userService.join(joinDto);
-
-        return ResponseEntity.ok(userDto);
-    }
-
-    @PostMapping("/login")
-    public ResponseEntity<JwtToken> login(@RequestBody LoginDto loginDto) {
-        JwtToken jwtToken = userService.login(loginDto);
-
-        return ResponseEntity.ok(jwtToken);
-    }
-
-    @PostMapping("/logout")
-    public ResponseEntity<Void> logout() {
-        userService.logout();
-
-        return ResponseEntity.noContent().build();
-    }
-
-    @PostMapping("/reissue-token")
-    public ResponseEntity<JwtToken> reissueToken(@RequestHeader(HttpHeaders.AUTHORIZATION) String bearerToken) {
-        JwtToken jwtToken = userService.reissueToken(bearerToken);
-
-        return ResponseEntity.ok(jwtToken);
-    }
-
     @GetMapping("/{userId}")
     public ResponseEntity<UserDto> findUserInfo(@PathVariable Long userId, UserType userType) {
         UserDto userDto = userService.findUser(userId, userType);

--- a/src/main/java/com/mednine/pillbuddy/domain/user/service/AuthService.java
+++ b/src/main/java/com/mednine/pillbuddy/domain/user/service/AuthService.java
@@ -1,0 +1,93 @@
+package com.mednine.pillbuddy.domain.user.service;
+
+import com.mednine.pillbuddy.domain.user.caregiver.repository.CaregiverRepository;
+import com.mednine.pillbuddy.domain.user.caretaker.repository.CaretakerRepository;
+import com.mednine.pillbuddy.domain.user.dto.JoinDto;
+import com.mednine.pillbuddy.domain.user.dto.LoginDto;
+import com.mednine.pillbuddy.domain.user.dto.UserDto;
+import com.mednine.pillbuddy.global.exception.ErrorCode;
+import com.mednine.pillbuddy.global.exception.PillBuddyCustomException;
+import com.mednine.pillbuddy.global.jwt.JwtToken;
+import com.mednine.pillbuddy.global.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AuthService {
+
+    private final CaretakerRepository caretakerRepository;
+    private final CaregiverRepository caregiverRepository;
+    private final MyUserDetailsService userDetailsService;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final PasswordEncoder passwordEncoder;
+
+    public UserDto join(JoinDto joinDto) {
+        validateUserInfo(joinDto.getLoginId(), joinDto.getEmail(), joinDto.getPhoneNumber());
+
+        // 비밀번호 암호화
+        String encodedPassword = passwordEncoder.encode(joinDto.getPassword());
+        joinDto.changeEncodedPassword(encodedPassword);
+
+        // 사용자 타입에 따라 회원 저장
+        return switch (joinDto.getUserType()) {
+            case CAREGIVER -> new UserDto(caregiverRepository.save(joinDto.toCaregiverEntity()));
+            case CARETAKER -> new UserDto(caretakerRepository.save(joinDto.toCaretakerEntity()));
+        };
+    }
+
+    @Transactional(readOnly = true)
+    public JwtToken login(LoginDto loginDto) {
+        // 로그인 아이디를 통해 회원 조회
+        CustomUserDetails userDetails = userDetailsService.loadUserByUsername(loginDto.getLoginId());
+
+        // 비밀번호 일치 여부 확인
+        if (!passwordEncoder.matches(loginDto.getPassword(), userDetails.getPassword())) {
+            throw new PillBuddyCustomException(ErrorCode.USER_MISMATCHED_ID_OR_PASSWORD);
+        }
+
+        // 로그인 아이디를 통해 Jwt 토큰 생성 후 반환
+        return jwtTokenProvider.generateToken(loginDto.getLoginId());
+    }
+
+    @Transactional(propagation = Propagation.NEVER)
+    public void logout() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null) {
+            throw new PillBuddyCustomException(ErrorCode.USER_AUTHENTICATION_REQUIRED);
+        }
+        SecurityContextHolder.clearContext();
+    }
+
+    @Transactional(readOnly = true)
+    public JwtToken reissueToken(String bearerToken) {
+        // 토큰 가져오기
+        String refreshToken = jwtTokenProvider.resolveToken(bearerToken);
+
+        // 토큰 유효성 검사
+        if (refreshToken == null || !jwtTokenProvider.validateToken(refreshToken) || !jwtTokenProvider.isRefreshToken(refreshToken)) {
+            throw new PillBuddyCustomException(ErrorCode.JWT_TOKEN_INVALID);
+        }
+
+        return jwtTokenProvider.reissueAccessToken(refreshToken);
+    }
+
+    private void validateUserInfo(String loginId, String email, String phoneNumber) {
+        if (caregiverRepository.existsByLoginId(loginId) || caretakerRepository.existsByLoginId(loginId)) {
+            throw new PillBuddyCustomException(ErrorCode.USER_ALREADY_REGISTERED_LOGIN_ID);
+        }
+        if (caregiverRepository.existsByEmail(email) || caretakerRepository.existsByEmail(email)) {
+            throw new PillBuddyCustomException(ErrorCode.USER_ALREADY_REGISTERED_EMAIL);
+        }
+        if (caregiverRepository.existsByPhoneNumber(phoneNumber) || caretakerRepository.existsByPhoneNumber(phoneNumber)) {
+            throw new PillBuddyCustomException(ErrorCode.USER_ALREADY_REGISTERED_PHONE_NUMBER);
+        }
+    }
+}

--- a/src/main/java/com/mednine/pillbuddy/domain/user/service/UserService.java
+++ b/src/main/java/com/mednine/pillbuddy/domain/user/service/UserService.java
@@ -4,8 +4,6 @@ import com.mednine.pillbuddy.domain.user.caregiver.entity.Caregiver;
 import com.mednine.pillbuddy.domain.user.caregiver.repository.CaregiverRepository;
 import com.mednine.pillbuddy.domain.user.caretaker.entity.Caretaker;
 import com.mednine.pillbuddy.domain.user.caretaker.repository.CaretakerRepository;
-import com.mednine.pillbuddy.domain.user.dto.JoinDto;
-import com.mednine.pillbuddy.domain.user.dto.LoginDto;
 import com.mednine.pillbuddy.domain.user.dto.UserDto;
 import com.mednine.pillbuddy.domain.user.dto.UserPasswordUpdateDto;
 import com.mednine.pillbuddy.domain.user.dto.UserType;
@@ -14,14 +12,9 @@ import com.mednine.pillbuddy.domain.user.entity.User;
 import com.mednine.pillbuddy.domain.user.profile.entity.Image;
 import com.mednine.pillbuddy.global.exception.ErrorCode;
 import com.mednine.pillbuddy.global.exception.PillBuddyCustomException;
-import com.mednine.pillbuddy.global.jwt.JwtToken;
-import com.mednine.pillbuddy.global.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
@@ -32,59 +25,6 @@ public class UserService {
     private final CaretakerRepository caretakerRepository;
     private final CaregiverRepository caregiverRepository;
     private final PasswordEncoder passwordEncoder;
-    private final MyUserDetailsService userDetailsService;
-    private final JwtTokenProvider jwtTokenProvider;
-
-    public UserDto join(JoinDto joinDto) {
-        validateUserInfo(joinDto.getLoginId(), joinDto.getEmail(), joinDto.getPhoneNumber());
-
-        // 비밀번호 암호화
-        String encodedPassword = passwordEncoder.encode(joinDto.getPassword());
-        joinDto.changeEncodedPassword(encodedPassword);
-
-        // 사용자 타입에 따라 회원 저장
-        return switch (joinDto.getUserType()) {
-            case CAREGIVER -> new UserDto(caregiverRepository.save(joinDto.toCaregiverEntity()));
-            case CARETAKER -> new UserDto(caretakerRepository.save(joinDto.toCaretakerEntity()));
-        };
-    }
-
-    @Transactional(readOnly = true)
-    public JwtToken login(LoginDto loginDto) {
-        // 로그인 아이디를 통해 회원 조회
-        CustomUserDetails userDetails = userDetailsService.loadUserByUsername(loginDto.getLoginId());
-
-        // 비밀번호 일치 여부 확인
-        if (!passwordEncoder.matches(loginDto.getPassword(), userDetails.getPassword())) {
-            throw new PillBuddyCustomException(ErrorCode.USER_MISMATCHED_ID_OR_PASSWORD);
-        }
-
-        // 로그인 아이디를 통해 Jwt 토큰 생성 후 반환
-        return jwtTokenProvider.generateToken(loginDto.getLoginId());
-    }
-
-    @Transactional(propagation = Propagation.NEVER)
-    public void logout() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-
-        if (authentication == null) {
-            throw new PillBuddyCustomException(ErrorCode.USER_AUTHENTICATION_REQUIRED);
-        }
-        SecurityContextHolder.clearContext();
-    }
-
-    @Transactional(readOnly = true)
-    public JwtToken reissueToken(String bearerToken) {
-        // 토큰 가져오기
-        String refreshToken = jwtTokenProvider.resolveToken(bearerToken);
-
-        // 토큰 유효성 검사
-        if (refreshToken == null || !jwtTokenProvider.validateToken(refreshToken) || !jwtTokenProvider.isRefreshToken(refreshToken)) {
-            throw new PillBuddyCustomException(ErrorCode.JWT_TOKEN_INVALID);
-        }
-
-        return jwtTokenProvider.reissueAccessToken(refreshToken);
-    }
 
     @Transactional(readOnly = true)
     public UserDto findUser(Long userId, UserType userType) {

--- a/src/main/java/com/mednine/pillbuddy/global/config/RedisConfig.java
+++ b/src/main/java/com/mednine/pillbuddy/global/config/RedisConfig.java
@@ -1,0 +1,34 @@
+package com.mednine.pillbuddy.global.config;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public LettuceConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    @Qualifier(value = "BlackList")
+    public RedisTemplate<String, String> redisTemplate() {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/mednine/pillbuddy/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/mednine/pillbuddy/global/jwt/JwtTokenProvider.java
@@ -77,7 +77,7 @@ public class JwtTokenProvider {
         long remainingTime = claims.getExpiration().getTime() - new Date().getTime();
 
         // refreshToKen 과 Id, 남은 시간을 BlackList 에 저장
-        redisUtils.setBlackList(refreshToken, loginId, 1000L);
+        redisUtils.setBlackList(refreshToken, loginId, remainingTime);
 
         CustomUserDetails userDetails = myUserDetailsService.loadUserByUsername(loginId);
 

--- a/src/main/java/com/mednine/pillbuddy/global/redis/RedisUtils.java
+++ b/src/main/java/com/mednine/pillbuddy/global/redis/RedisUtils.java
@@ -1,0 +1,24 @@
+package com.mednine.pillbuddy.global.redis;
+
+import java.util.concurrent.TimeUnit;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RedisUtils {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public RedisUtils(@Qualifier(value = "BlackList") RedisTemplate<String, String> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    public void setBlackList(String token, String loginId, Long milliSeconds) {
+        redisTemplate.opsForValue().set(token, loginId, milliSeconds, TimeUnit.MILLISECONDS);
+    }
+
+    public boolean hasTokenBlackList(String token) {
+        return redisTemplate.hasKey(token);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,12 +1,18 @@
 spring:
   application.name: pill-buddy
   profiles.include: db
+
   jpa:
     properties.hibernate:
       format_sql: true
       highlight_sql: true
       use_sql_comments: true
     hibernate.ddl-auto: update
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
 
 logging:
   level:

--- a/src/test/java/com/mednine/pillbuddy/domain/user/service/AuthServiceTest.java
+++ b/src/test/java/com/mednine/pillbuddy/domain/user/service/AuthServiceTest.java
@@ -1,0 +1,227 @@
+package com.mednine.pillbuddy.domain.user.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.mednine.pillbuddy.domain.user.caregiver.entity.Caregiver;
+import com.mednine.pillbuddy.domain.user.caregiver.repository.CaregiverRepository;
+import com.mednine.pillbuddy.domain.user.caretaker.entity.Caretaker;
+import com.mednine.pillbuddy.domain.user.caretaker.repository.CaretakerRepository;
+import com.mednine.pillbuddy.domain.user.dto.JoinDto;
+import com.mednine.pillbuddy.domain.user.dto.LoginDto;
+import com.mednine.pillbuddy.domain.user.dto.UserDto;
+import com.mednine.pillbuddy.domain.user.dto.UserType;
+import com.mednine.pillbuddy.domain.user.entity.Role;
+import com.mednine.pillbuddy.global.exception.ErrorCode;
+import com.mednine.pillbuddy.global.exception.PillBuddyCustomException;
+import com.mednine.pillbuddy.global.jwt.JwtToken;
+import com.mednine.pillbuddy.global.jwt.JwtTokenProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class AuthServiceTest {
+
+    @Autowired
+    private AuthService authService;
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    private CaretakerRepository caretakerRepository;
+
+    @Autowired
+    private CaregiverRepository caregiverRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private Caretaker caretaker;
+
+    private Caregiver caregiver;
+
+    @BeforeEach
+    void setup() {
+        createCaretaker();
+        createCaregiver();
+        caretakerRepository.save(caretaker);
+        caregiverRepository.save(caregiver);
+    }
+
+    @Test
+    @DisplayName("JoinDto 를 통해 회원가입을 할 수 있다.")
+    void join() {
+        // given
+        JoinDto joinDto = new JoinDto(
+                "newUser", "newLoginId", "newPassword",
+                "new@gmail.com", "010-1112-2221", UserType.CARETAKER);
+
+        // when
+        UserDto userDto = authService.join(joinDto);
+
+        // then
+        assertThat(userDto.getUsername()).isEqualTo("newUser");
+        assertThat(userDto.getPhoneNumber()).isEqualTo("010-1112-2221");
+        assertThat(userDto.getEmail()).isEqualTo("new@gmail.com");
+        assertThat(userDto.getUserType()).isEqualTo("caretaker");
+    }
+
+    @Test
+    @DisplayName("JoinDto 를 통해 회원가입 시 중복된 이메일을 입력하면 예외가 발생한다.")
+    void join_with_duplicated_email_exception() {
+        String duplicatedEmail = "test-email";
+
+        JoinDto joinDto = new JoinDto(
+                "newUser", "newLoginId", "newPassword",
+                duplicatedEmail, "010-1112-2222", UserType.CARETAKER);
+
+        assertThatThrownBy(() -> authService.join(joinDto))
+                .isInstanceOf(PillBuddyCustomException.class)
+                .hasMessage(ErrorCode.USER_ALREADY_REGISTERED_EMAIL.getMessage());
+    }
+
+    @Test
+    @DisplayName("JoinDto 를 통해 회원가입 시 중복된 로그인 아이디를 입력하면 예외가 발생한다.")
+    void join_with_duplicated_login_id_exception() {
+        String duplicatedLoginId = "test-loginId";
+
+        JoinDto joinDto = new JoinDto(
+                "newUser", duplicatedLoginId, "newPassword",
+                "new@gmail.com", "010-1112-2223", UserType.CARETAKER);
+
+        assertThatThrownBy(() -> authService.join(joinDto))
+                .isInstanceOf(PillBuddyCustomException.class)
+                .hasMessage(ErrorCode.USER_ALREADY_REGISTERED_LOGIN_ID.getMessage());
+    }
+
+    @Test
+    @DisplayName("JoinDto 를 통해 회원가입 시 중복된 전화번호를 입력하면 예외가 발생한다.")
+    void join_with_duplicated_phoneNumber_exception() {
+        String duplicatedPhoneNumber = "test-phoneNumber";
+
+        JoinDto joinDto = new JoinDto(
+                "newUser", "newLoginId", "newPassword",
+                "new@gmail.com", duplicatedPhoneNumber, UserType.CARETAKER);
+
+        assertThatThrownBy(() -> authService.join(joinDto))
+                .isInstanceOf(PillBuddyCustomException.class)
+                .hasMessage(ErrorCode.USER_ALREADY_REGISTERED_PHONE_NUMBER.getMessage());
+    }
+
+    @Test
+    @DisplayName("LoginDto 를 통해 로그인을 할 수 있다.")
+    void login() {
+        // given
+        String loginId = caretaker.getLoginId();
+        String password = "test-password";
+        LoginDto loginDto = new LoginDto(loginId, password);
+
+        // when
+        JwtToken jwtToken = authService.login(loginDto);
+        Authentication authentication = jwtTokenProvider.getAuthenticationByToken(jwtToken.getAccessToken());
+
+        // then
+        assertThat(jwtToken.getGrantType()).isEqualTo("Bearer");
+        assertThat(authentication.getAuthorities().iterator().next().getAuthority()).isEqualTo("ROLE_USER");
+        assertThat(authentication.getName()).isEqualTo(loginId);
+    }
+
+    @Test
+    @DisplayName("LoginId 를 찾을 수 없다면, InternalAuthenticationServiceException 이 발생한다.")
+    void login_with_invalid_loginId() {
+        String invalidLoginId = "invalidLoginId";
+        String password = "password3";
+        LoginDto loginDto = new LoginDto(invalidLoginId, password);
+
+        // when
+        assertThatThrownBy(() -> authService.login(loginDto))
+                .isInstanceOf(PillBuddyCustomException.class)
+                .hasMessage(ErrorCode.USER_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("password 가 저장된 비밀번호와 일치하지 않다면, BadCredentialsException 이 발생한다.")
+    void login_with_invalid_password() {
+        String loginId = caretaker.getLoginId();
+        String invalidPassword = "invalidPassword";
+        LoginDto loginDto = new LoginDto(loginId, invalidPassword);
+
+        // when
+        assertThatThrownBy(() -> authService.login(loginDto))
+                .isInstanceOf(PillBuddyCustomException.class)
+                .hasMessage(ErrorCode.USER_MISMATCHED_ID_OR_PASSWORD.getMessage());
+    }
+
+    @Test
+    @DisplayName("사용자는 refreshToken 을 통해 토큰을 재발급 할 수 있다.")
+    void reissueToken() {
+        // given
+        String loginId = caretaker.getLoginId();
+        String password = "test-password";
+        LoginDto loginDto = new LoginDto(loginId, password);
+
+        JwtToken jwtToken = authService.login(loginDto);
+        String refreshToken = "Bearer " + jwtToken.getRefreshToken();
+
+        // when
+        JwtToken reissuedJwtToken = authService.reissueToken(refreshToken);
+        String reissuedAccessToken = reissuedJwtToken.getAccessToken();
+        Authentication authentication = jwtTokenProvider.getAuthenticationByToken(reissuedAccessToken);
+
+        // then
+        assertThat(authentication.getName()).isEqualTo(loginId);
+        assertThat(authentication.getAuthorities().iterator().next().getAuthority()).isEqualTo("ROLE_USER");
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 refreshToken 이면, PillBuddyException 이 발생한다.")
+    void reissueToken_with_expired_refreshToken() {
+        // given
+        String malformedRefreshToken = "Bearer malformed_jwt_token";
+
+        assertThatThrownBy(() -> authService.reissueToken(malformedRefreshToken))
+                .isInstanceOf(PillBuddyCustomException.class)
+                .hasMessage("유효하지 않은 JWT 토큰입니다.");
+    }
+
+    @Test
+    @DisplayName("GrantType 이 없는 refreshToken 이면, PillBuddyException 이 발생한다.")
+    void reissueToken_without_grantType() {
+        // given
+        String refreshToken = "simple_refresh_token";
+
+        assertThatThrownBy(() -> authService.reissueToken(refreshToken))
+                .isInstanceOf(PillBuddyCustomException.class)
+                .hasMessage("유효하지 않은 JWT 토큰입니다.");
+    }
+
+    private void createCaretaker() {
+        caretaker = Caretaker.builder()
+                .username("test-caretaker")
+                .loginId("test-loginId")
+                .password(passwordEncoder.encode("test-password"))
+                .email("test-email")
+                .phoneNumber("test-phoneNumber")
+                .role(Role.USER)
+                .build();
+    }
+
+    private void createCaregiver() {
+        caregiver = Caregiver.builder()
+                .username("test-caregiver")
+                .loginId("test-loginId")
+                .password(passwordEncoder.encode("test-password"))
+                .email("test-email")
+                .phoneNumber("test-phoneNumber")
+                .role(Role.USER)
+                .build();
+    }
+}

--- a/src/test/java/com/mednine/pillbuddy/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/mednine/pillbuddy/domain/user/service/UserServiceTest.java
@@ -7,22 +7,17 @@ import com.mednine.pillbuddy.domain.user.caregiver.entity.Caregiver;
 import com.mednine.pillbuddy.domain.user.caregiver.repository.CaregiverRepository;
 import com.mednine.pillbuddy.domain.user.caretaker.entity.Caretaker;
 import com.mednine.pillbuddy.domain.user.caretaker.repository.CaretakerRepository;
-import com.mednine.pillbuddy.domain.user.dto.JoinDto;
-import com.mednine.pillbuddy.domain.user.dto.LoginDto;
 import com.mednine.pillbuddy.domain.user.dto.UserDto;
 import com.mednine.pillbuddy.domain.user.dto.UserType;
 import com.mednine.pillbuddy.domain.user.dto.UserUpdateDto;
 import com.mednine.pillbuddy.domain.user.entity.Role;
 import com.mednine.pillbuddy.global.exception.ErrorCode;
 import com.mednine.pillbuddy.global.exception.PillBuddyCustomException;
-import com.mednine.pillbuddy.global.jwt.JwtToken;
-import com.mednine.pillbuddy.global.jwt.JwtTokenProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -32,9 +27,6 @@ class UserServiceTest {
 
     @Autowired
     private UserService userService;
-
-    @Autowired
-    private JwtTokenProvider jwtTokenProvider;
 
     @Autowired
     private CaretakerRepository caretakerRepository;
@@ -57,152 +49,6 @@ class UserServiceTest {
         caregiverRepository.save(caregiver);
     }
 
-    @Test
-    @DisplayName("JoinDto 를 통해 회원가입을 할 수 있다.")
-    void join() {
-        // given
-        JoinDto joinDto = new JoinDto(
-                "newUser", "newLoginId", "newPassword",
-                "new@gmail.com", "010-1112-2221", UserType.CARETAKER);
-
-        // when
-        UserDto userDto = userService.join(joinDto);
-
-        // then
-        assertThat(userDto.getUsername()).isEqualTo("newUser");
-        assertThat(userDto.getPhoneNumber()).isEqualTo("010-1112-2221");
-        assertThat(userDto.getEmail()).isEqualTo("new@gmail.com");
-        assertThat(userDto.getUserType()).isEqualTo("caretaker");
-    }
-
-    @Test
-    @DisplayName("JoinDto 를 통해 회원가입 시 중복된 이메일을 입력하면 예외가 발생한다.")
-    void join_with_duplicated_email_exception() {
-        String duplicatedEmail = "test-email";
-
-        JoinDto joinDto = new JoinDto(
-                "newUser", "newLoginId", "newPassword",
-                duplicatedEmail, "010-1112-2222", UserType.CARETAKER);
-
-        assertThatThrownBy(() -> userService.join(joinDto))
-                .isInstanceOf(PillBuddyCustomException.class)
-                .hasMessage(ErrorCode.USER_ALREADY_REGISTERED_EMAIL.getMessage());
-    }
-
-    @Test
-    @DisplayName("JoinDto 를 통해 회원가입 시 중복된 로그인 아이디를 입력하면 예외가 발생한다.")
-    void join_with_duplicated_login_id_exception() {
-        String duplicatedLoginId = "test-loginId";
-
-        JoinDto joinDto = new JoinDto(
-                "newUser", duplicatedLoginId, "newPassword",
-                "new@gmail.com", "010-1112-2223", UserType.CARETAKER);
-
-        assertThatThrownBy(() -> userService.join(joinDto))
-                .isInstanceOf(PillBuddyCustomException.class)
-                .hasMessage(ErrorCode.USER_ALREADY_REGISTERED_LOGIN_ID.getMessage());
-    }
-
-    @Test
-    @DisplayName("JoinDto 를 통해 회원가입 시 중복된 전화번호를 입력하면 예외가 발생한다.")
-    void join_with_duplicated_phoneNumber_exception() {
-        String duplicatedPhoneNumber = "test-phoneNumber";
-
-        JoinDto joinDto = new JoinDto(
-                "newUser", "newLoginId", "newPassword",
-                "new@gmail.com", duplicatedPhoneNumber, UserType.CARETAKER);
-
-        assertThatThrownBy(() -> userService.join(joinDto))
-                .isInstanceOf(PillBuddyCustomException.class)
-                .hasMessage(ErrorCode.USER_ALREADY_REGISTERED_PHONE_NUMBER.getMessage());
-    }
-
-    @Test
-    @DisplayName("LoginDto 를 통해 로그인을 할 수 있다.")
-    void login() {
-        // given
-        String loginId = caretaker.getLoginId();
-        String password = "test-password";
-        LoginDto loginDto = new LoginDto(loginId, password);
-
-        // when
-        JwtToken jwtToken = userService.login(loginDto);
-        Authentication authentication = jwtTokenProvider.getAuthenticationByToken(jwtToken.getAccessToken());
-
-        // then
-        assertThat(jwtToken.getGrantType()).isEqualTo("Bearer");
-        assertThat(authentication.getAuthorities().iterator().next().getAuthority()).isEqualTo("ROLE_USER");
-        assertThat(authentication.getName()).isEqualTo(loginId);
-    }
-
-    @Test
-    @DisplayName("LoginId 를 찾을 수 없다면, InternalAuthenticationServiceException 이 발생한다.")
-    void login_with_invalid_loginId() {
-        String invalidLoginId = "invalidLoginId";
-        String password = "password3";
-        LoginDto loginDto = new LoginDto(invalidLoginId, password);
-
-        // when
-        assertThatThrownBy(() -> userService.login(loginDto))
-                .isInstanceOf(PillBuddyCustomException.class)
-                .hasMessage(ErrorCode.USER_NOT_FOUND.getMessage());
-    }
-
-    @Test
-    @DisplayName("password 가 저장된 비밀번호와 일치하지 않다면, BadCredentialsException 이 발생한다.")
-    void login_with_invalid_password() {
-        String loginId = caretaker.getLoginId();
-        String invalidPassword = "invalidPassword";
-        LoginDto loginDto = new LoginDto(loginId, invalidPassword);
-
-        // when
-        assertThatThrownBy(() -> userService.login(loginDto))
-                .isInstanceOf(PillBuddyCustomException.class)
-                .hasMessage(ErrorCode.USER_MISMATCHED_ID_OR_PASSWORD.getMessage());
-    }
-
-    @Test
-    @DisplayName("사용자는 refreshToken 을 통해 토큰을 재발급 할 수 있다.")
-    void reissueToken() {
-        // given
-        String loginId = caretaker.getLoginId();
-        String password = "test-password";
-        LoginDto loginDto = new LoginDto(loginId, password);
-
-        JwtToken jwtToken = userService.login(loginDto);
-        String refreshToken = "Bearer " + jwtToken.getRefreshToken();
-
-        // when
-        JwtToken reissuedJwtToken = userService.reissueToken(refreshToken);
-        String reissuedAccessToken = reissuedJwtToken.getAccessToken();
-        Authentication authentication = jwtTokenProvider.getAuthenticationByToken(reissuedAccessToken);
-
-        // then
-        assertThat(authentication.getName()).isEqualTo(loginId);
-        assertThat(authentication.getAuthorities().iterator().next().getAuthority()).isEqualTo("ROLE_USER");
-    }
-
-    @Test
-    @DisplayName("유효하지 않은 refreshToken 이면, PillBuddyException 이 발생한다.")
-    void reissueToken_with_expired_refreshToken() {
-        // given
-        String malformedRefreshToken = "Bearer malformed_jwt_token";
-
-        assertThatThrownBy(() -> userService.reissueToken(malformedRefreshToken))
-                .isInstanceOf(PillBuddyCustomException.class)
-                .hasMessage("유효하지 않은 JWT 토큰입니다.");
-    }
-
-    @Test
-    @DisplayName("GrantType 이 없는 refreshToken 이면, PillBuddyException 이 발생한다.")
-    void reissueToken_without_grantType() {
-        // given
-        String refreshToken = "simple_refresh_token";
-
-        assertThatThrownBy(() -> userService.reissueToken(refreshToken))
-                .isInstanceOf(PillBuddyCustomException.class)
-                .hasMessage("유효하지 않은 JWT 토큰입니다.");
-    }
 
     @Test
     @DisplayName("사용자를 조회할 수 있다.")

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -19,6 +19,10 @@ spring:
       data-locations: classpath:sql/data.sql
       encoding: UTF-8
       mode: always
+  data:
+    redis:
+      port: 6379
+      host: localhost
 
 logging.level:
   org.hibernate.SQL: debug


### PR DESCRIPTION
## 👩‍💻작업 내용
인메모리 데이터베이스 Redis 를 사용하여 refreshToken 저장 및 관리하는 기능을 구현하였습니다!
 
아래는 개발 전 사용자 흐름 입니다.
```text
// 로그인
1. 사용자가 로그인 요청을 보낸다.
2. 데이터베이스에서 사용자를 조회하고, 비밀번호 일치 여부를 확인한다.
3. accessToken, refreshToken 을 함께 발급해준다.

// 재발급
1. 사용자가 accessToken이 만료되면, 함께 발급해준 refreshToken을 통해 토큰 재발급 요청을 보낸다.
2. 서버에서 refreshToken의 유효성 검사를 진행한다.
3. 새로운 accessToken, refreshToken 을 함께 발급해준다.
```

refreshToken 의 유효기간은 길기 때문에 악의적으로 refreshToken을 통해서 수많은 accessToken을 재발급 할 수 있는 위험이 있습니다.
따라서 아래와 같은 흐름으로 변경하여, 재발급 후 refreshToken을 무효화했습니다.

```text
// 재발급
1. 사용자가 accessToken이 만료되면, 함께 발급해준 refreshToken을 통해 토큰 재발급 요청을 보낸다.
2. 서버에서 refreshToken의 유효성 검사와 Redis DB의 BlackList 에 refreshToken 이 있는지 확인한다.
3. 새로운 accessToken, refreshToken 을 함께 발급해준다.
4. 이때, 재발급에 사용된 refreshToken은 Redis DB의 BlackList 에 저장한다.
```

+ User 도메인의 역할이 너무 커져서 패키지 내에서 Auth 도메인을 만들어서 분리하였습니다. 따라서 test 코드도 분리했습니다 !

## 💬리뷰 요구 사항
로직 오류 및 오타 확인부탁드립니다!

## 📃참고 자료
[참고 자료!](https://codingwell.tistory.com/188)
[참고 자료2!](https://velog.io/@boo105/Redis-%EB%A5%BC-%ED%86%B5%ED%95%9C-JWT-Blacklist-%EA%B5%AC%ED%98%84)
