### PR TITLE
75:[FIX] Swagger API 경로 시큐리티 설정

### DIFF
--- a/src/main/java/com/medinine/pillbuddy/global/config/SecurityConfig.java
+++ b/src/main/java/com/medinine/pillbuddy/global/config/SecurityConfig.java
@@ -47,10 +47,12 @@ public class SecurityConfig {
                 // api 테스트 시 편의를 위해 잠시 모든 요청 허용
                 .authorizeHttpRequests(req ->
                         req.requestMatchers("/api/users/join",
-                                            "/api/users/login",
-                                            "/api/users/reissue-token",
-                                            "api/search").permitAll()
-                            .anyRequest().hasRole("USER")
+                                        "/api/users/login",
+                                        "/api/users/reissue-token",
+                                        "api/search",
+                                        "/swagger-ui/**",
+                                        "/v3/api-docs/**").permitAll()
+                                .anyRequest().hasRole("USER")
                 )
                 .addFilterBefore(authenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .build();


### PR DESCRIPTION
## 👩‍💻작업 내용
Swagger 경로를 허용하지 않아서 문서 접근이 불가능한 오류를 해결

